### PR TITLE
Rescue

### DIFF
--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -1021,8 +1021,9 @@ const clivalue_t valueTable[] = {
     { "horizon_tilt_effect",        VAR_UINT8  | PROFILE_VALUE, .config.minmaxUnsigned = { 0,  250 }, PG_PID_PROFILE, offsetof(pidProfile_t, horizon_tilt_effect) },
     { "horizon_tilt_expert_mode",   VAR_UINT8  | PROFILE_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_PID_PROFILE, offsetof(pidProfile_t, horizon_tilt_expert_mode) },
 
+	{ "rescue_delay",          		VAR_UINT8  | PROFILE_VALUE, .config.minmaxUnsigned = { 0, 35 }, PG_PID_PROFILE, offsetof(pidProfile_t, rescue_delay) },
     { "rescue_collective",          VAR_UINT16 | PROFILE_VALUE, .config.minmaxUnsigned = { 0, 1000 }, PG_PID_PROFILE, offsetof(pidProfile_t, rescue_collective) },
-
+	{ "rescue_boost",          		VAR_UINT16 | PROFILE_VALUE, .config.minmaxUnsigned = { 0, 600 }, PG_PID_PROFILE, offsetof(pidProfile_t, rescue_boost) },	
 #if defined(USE_ABSOLUTE_CONTROL)
     { "abs_control",                VAR_UINT8 | PROFILE_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_PID_PROFILE, offsetof(pidProfile_t, abs_control) },
     { "abs_control_gain",           VAR_UINT8 | PROFILE_VALUE,  .config.minmaxUnsigned = { 0, 200 }, PG_PID_PROFILE, offsetof(pidProfile_t, abs_control_gain) },

--- a/src/main/flight/leveling.c
+++ b/src/main/flight/leveling.c
@@ -79,7 +79,7 @@ float pidRescueCollective(void)
 	
 	// boost rescue collective until rescue delay expires 
 	if (!delayComplete()) {
-		tempcollective = rescueCollective + rescueBoost;	
+		tempcollective = constrainf(rescueCollective + rescueBoost, 0, 1);	
 	} else {
 		tempcollective = rescueCollective; 
 	}

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -120,7 +120,9 @@ void resetPidProfile(pidProfile_t *pidProfile)
         .yaw_collective_ff_impulse_gain = 20,
         .yaw_collective_ff_impulse_freq = 100,
         .rate_normalization = RATE_NORM_ABSOLUTE,
+		.rescue_delay = 35,
         .rescue_collective = 0,
+        .rescue_boost = 0,						   
     );
 }
 
@@ -190,12 +192,23 @@ static FAST_RAM_ZERO_INIT float itermDecay;
 static FAST_RAM_ZERO_INIT bool itermRotation;
 #endif
 
+#ifdef USE_ACC
+static FAST_RAM_ZERO_INIT bool rescueInvert;
+static FAST_RAM_ZERO_INIT uint8_t rescueDelay;
+static FAST_RAM_ZERO_INIT uint16_t rescueDelayTarget;
+static FAST_RAM_ZERO_INIT uint16_t rescueDelayCurrent;
+
+#endif  
 
 float pidGetDT()
 {
     return dT;
 }
 
+bool delayComplete()
+{
+	return rescueInvert;
+}
 float pidGetPidFrequency()
 {
     return pidFrequency;
@@ -285,6 +298,8 @@ void pidInitConfig(const pidProfile_t *pidProfile)
 
 #ifdef USE_ACC
     pidLevelInit(pidProfile);
+	rescueDelay = pidProfile->rescue_delay;
+	rescueDelayTarget = rescueDelay/dT/10 ;
 #endif
 #ifdef USE_ACRO_TRAINER
     acroTrainerInit(pidProfile);
@@ -601,14 +616,23 @@ static FAST_CODE void pidNormaliseCollective(void)
 {
     float collective;
 
-    if (FLIGHT_MODE(RESCUE_MODE))
+    if (FLIGHT_MODE(RESCUE_MODE)) {
+		if (rescueDelay < 35) {		//set to 35 to disable delayed roll to upright rescue
+			if (rescueDelayCurrent < rescueDelayTarget) {
+				rescueDelayCurrent++;
+			} else {
+				rescueInvert = true;
+			}
+		}
         collective = pidRescueCollective();
-    else
-        collective = rcCommand[COLLECTIVE] * MIXER_RC_SCALING * getRateNormalizationGain(FD_COLL, pidHeadspeedRatio);
-
+	} else {
+        rescueInvert = false;
+		rescueDelayCurrent = 0;
+		collective = rcCommand[COLLECTIVE] * MIXER_RC_SCALING * getRateNormalizationGain(FD_COLL, pidHeadspeedRatio);
+	}
     collectiveCommand = collective * getNormalizationGain(FD_COLL, pidHeadspeedRatio);
-}
-
+	
+}	
 static FAST_CODE void pidApplyAxis(const pidProfile_t *pidProfile, uint8_t axis)
 {
     // Normalised Setpoint rate

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -178,7 +178,9 @@ typedef struct pidProfile_s
 
     uint8_t   rate_normalization;             // Type of pitch/roll rate normalization
 
-    uint16_t  rescue_collective;              // Collective value for rescue
+    uint8_t   rescue_delay;              		// Timer for non-inverted rescue. Value = Sec *10. 1s == 10. Set to 35 to disable 
+	uint16_t  rescue_collective;              	// Collective value for rescue
+	uint16_t  rescue_boost;              		// Boost Collective value for rescue. Added to rescue_collective until delay has expired
 
 } pidProfile_t;
 
@@ -204,6 +206,7 @@ void pidUpdateSetpointDerivativeLpf(uint16_t filterCutoff);
 float pidGetDT();
 float pidGetPidFrequency();
 uint32_t pidGetLooptime();
+extern bool 	delayComplete();	 
 
 float pidGetSetpoint(int axis);
 


### PR DESCRIPTION
* Rescue collective boost (high speed to gain altitude)
* After time delay drop to normal rescue collective speed (rescue_collective)
* If heli is inverted it will now roll to upright

Added CLI:
rescue_delay. (0-35) time delay in s *10. Set to 35 will disable roll from inverted
rescue_boost. Value added to rescue_collective for rapid collective until delay expires
