### PR TITLE
Docker files.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM ubuntu:bionic
+RUN apt-get -y update
+RUN apt-get -y upgrade
+RUN apt-get -y install \
+    build-essential \
+    curl \
+    git \
+    python
+
+RUN mkdir /rotorflight
+WORKDIR /rotorflight

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,4 @@
-services:
-  rotorflight:
-    build: .
-    volumes:
-      - ./:/rotorflight
+rotorflight:
+  build: .
+  volumes:
+    - ./:/rotorflight

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,5 @@
+services:
+  rotorflight:
+    build: .
+    volumes:
+      - ./:/rotorflight


### PR DESCRIPTION
Add simple Docker build container. This will allow users on systems with Docker installed to check out the repo and build the firmware with:

```bash
docker compose run rotorflight make arm_sdk_install
docker compose run rotorflight make STM32F411
```

After this is merged I can update the wiki.