### PR TITLE
Move GS_LOST_THROTTLE state to isSpooledUp() == false

### DIFF
--- a/src/main/flight/governor.c
+++ b/src/main/flight/governor.c
@@ -236,12 +236,12 @@ bool isSpooledUp(void)
         {
             case GS_ACTIVE:
             case GS_RECOVERY:
-            case GS_LOST_THROTTLE:
             case GS_LOST_HEADSPEED:
             case GS_AUTOROTATION:
             case GS_AUTOROTATION_BAILOUT:
                 return true;
 
+            case GS_LOST_THROTTLE:
             case GS_THROTTLE_OFF:
             case GS_THROTTLE_IDLE:
             case GS_SPOOLING_UP:


### PR DESCRIPTION
Throttle < min_check  (throttle hold) should instantly stop power to both motors.  Currently motorized tail continues to run for a few seconds if governor was previously active.  Impact of changing spooled up status will also begin iterm decay and prevent accumulation of absolute control error for this state.  Also, during a momentary loss of throttle signal such as an inadvertent flip of the throttle hold switch, the heli will start to spin when the tail motor stops (although not much since the main motor will also be at zero power).