### PR TITLE
Changed Spektrum SRXL CMS display port title to ROTORFLIGHT

### DIFF
--- a/src/main/io/displayport_srxl.c
+++ b/src/main/io/displayport_srxl.c
@@ -74,7 +74,7 @@ static int srxlClearScreen(displayPort_t *displayPort)
             srxlWriteChar(displayPort, col, row, DISPLAYPORT_ATTR_NONE, ' ');
         }
     }
-    srxlWriteString(displayPort, 1, 0, DISPLAYPORT_ATTR_NONE, "BETAFLIGHT");
+    srxlWriteString(displayPort, 1, 0, DISPLAYPORT_ATTR_NONE, "ROTORFLIGHT");
 
     if (displayPort->grabCount == 0) {
         srxlWriteString(displayPort, 0, 2, DISPLAYPORT_ATTR_NONE, CMS_STARTUP_HELP_TEXT1);


### PR DESCRIPTION
CMS title was still saying BETAFLIGHT. Now says ROTORFLIGHT. Tested on a REVO F4 fc with Spektrum iX20 and DPM4651T in an old GAUI 550 Hurricane test mule.
![Screenshot_2022-02-01_154806](https://user-images.githubusercontent.com/15121917/151991648-d1dccf9f-ffef-4d05-b208-185c27e49243.jpg)

