### PR TITLE
Added MSP_SET_MOTOR

### DIFF
--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -2162,6 +2162,18 @@ static mspResult_e mspProcessInCommand(mspDescriptor_t srcDesc, int16_t cmdMSP, 
         }
         break;
 
+    case MSP_SET_MOTOR:
+#ifdef USE_MOTOR
+        for (int i = 0; i < getMotorCount(); i++) {
+            int throttle = sbufReadU16(src);
+            if (motorIsEnabled() && motorIsMotorEnabled(i)) {
+                if (throttle >= 1000 && throttle <= 2000)
+                    setMotorOverride(i, throttle - 1000);
+            }
+        }
+#endif
+        break;
+
     case MSP_SET_MOTOR_OVERRIDE:
 #ifdef USE_MOTOR
         i = sbufReadU8(src);


### PR DESCRIPTION
Testing motors from BLHeliSuite or ESC Configurator doesn't work because MSP_SET_MOTOR isn't implemented and this confuses some customers. This PR adds MSP_SET_MOTOR in order to avoid any further confusion.

![image](https://user-images.githubusercontent.com/34315684/227262765-eec07b5d-ebff-4f36-91a0-fc9937e1e6d6.png)
