### PR TITLE
feat: led strip 'arm state' tweak

### DIFF
--- a/docs/LedStrip.md
+++ b/docs/LedStrip.md
@@ -407,7 +407,7 @@ This mode flashes LEDs that correspond to roll and pitch stick positions.  i.e. 
 
 #### Armed state
 
-This mode toggles LEDs between green and blue when disarmed and armed, respectively.
+This mode toggles LEDs between green and blue when disarmed and armed, respectively. If arming is disabled the LED will be set to the background color, which usually is black.
 
 Note: Armed State cannot be used with Flight Mode.
 

--- a/src/main/io/ledstrip.c
+++ b/src/main/io/ledstrip.c
@@ -534,7 +534,7 @@ static void applyLedFixedLayers(void)
             break;
 
         case LED_FUNCTION_ARM_STATE:
-            color = ARMING_FLAG(ARMED) ? *getSC(LED_SCOLOR_ARMED) : *getSC(LED_SCOLOR_DISARMED);
+            color = !ARMING_FLAG(ARMED) && isArmingDisabled() ? *getSC(LED_SCOLOR_BACKGROUND) : ARMING_FLAG(ARMED) ? *getSC(LED_SCOLOR_ARMED) : *getSC(LED_SCOLOR_DISARMED);
             break;
 
         case LED_FUNCTION_BATTERY:


### PR DESCRIPTION
The 'arm state' mode now only shows armed/disarmed colors if there's no arming lock. If there is an arming lock, the background color will be shown, which is usually black.