### PR TITLE
Dyn notch - more consistent filter latency

### DIFF
--- a/src/main/flight/dyn_notch_filter.c
+++ b/src/main/flight/dyn_notch_filter.c
@@ -95,7 +95,7 @@ typedef enum {
     STEP_WINDOW,
     STEP_DETECT_PEAKS,
     STEP_CALC_FREQUENCIES,
-    STEP_UPDATE_FILTERS,
+    //STEP_UPDATE_FILTERS,
     STEP_COUNT
 
 } step_e;
@@ -264,16 +264,16 @@ static FAST_CODE void dynNotchProcess(void)
         {
             sdftWinSq(&sdft[state.axis], sdftData);
 
-            break;
-        }
-        case STEP_DETECT_PEAKS: // 5.5us (4-7us) @ F722
-        {
             // Get memory ready for new peak data on current axis
             for (int p = 0; p < dynNotch.count; p++) {
                 peaks[p].bin = 0;
                 peaks[p].value = 0.0f;
             }
 
+            break;
+        }
+        case STEP_DETECT_PEAKS: // 5.5us (4-7us) @ F722
+        {
             // Search for N biggest peaks in frequency spectrum
             for (int bin = (sdftStartBin + 1); bin < sdftEndBin; bin++) {
                 // Check if bin is peak
@@ -339,10 +339,10 @@ static FAST_CODE void dynNotchProcess(void)
                     }
                 }
             }
-            break;
-        }
-        case STEP_UPDATE_FILTERS: // 5.4us (2-9us) @ F722
-        {
+        //    break;
+        //}
+        //case STEP_UPDATE_FILTERS: // 5.4us (2-9us) @ F722
+        //{
             for (int p = 0; p < dynNotch.count; p++) {
                 // Only update notch filter coefficients if the corresponding peak got its center frequency updated in the previous step
                 if (peaks[p].bin != 0 && peaks[p].value > 0.0f) {


### PR DESCRIPTION
I did some profiling on dyn notch and small experiment 
the idea here is that `dynNotchProcess` do it's job in 4 steps, and last two steps can be merged into one, as they are pretty short, then we get more consistent timings

![dyn_notch_original_6_notches](https://github.com/rotorflight/rotorflight-firmware/assets/1812055/477a4e66-759a-4a33-ac12-6da6a64cf9c0)

![dyn_notch_improve_6_notches](https://github.com/rotorflight/rotorflight-firmware/assets/1812055/1fe0f14d-5f2a-4ab5-98f4-c26c6b180361)

![dyn_notch_improve_3_notches](https://github.com/rotorflight/rotorflight-firmware/assets/1812055/ac8c57d6-b20e-4a55-b220-d7771b70dbab)

in the original version timings are (us): 17, 24, 14, 19
in the updated version there are (us): 17, 25, 24
if there are only 3 notches, we get 16-19 us
most time consuming step is detect_peaks

Pros
- 3 steps allows to update notch filters more frequently
- overall timing is more consistent in every loop iteration
Cons
- overral processing time is bit higher in every loop iteration