### PR TITLE
feat: support for omp m1 tail esc

### DIFF
--- a/src/main/flight/servos.h
+++ b/src/main/flight/servos.h
@@ -34,7 +34,7 @@
 #define SERVO_SCALE_MIN        100
 #define SERVO_SCALE_MAX       1000
 #define SERVO_RATE_MIN          50
-#define SERVO_RATE_MAX        1000
+#define SERVO_RATE_MAX        2600
 #define SERVO_SPEED_MIN          0
 #define SERVO_SPEED_MAX      60000
 #define SERVO_OVERRIDE_MIN   -2000

--- a/src/main/rx/rx.h
+++ b/src/main/rx/rx.h
@@ -48,7 +48,7 @@
 #define PWM_PULSE_MIN           750       // minimum PWM pulse width which is considered valid
 #define PWM_PULSE_MAX           2250      // maximum PWM pulse width which is considered valid
 
-#define PWM_SERVO_PULSE_MIN     375       // minimum PWM servo output pulse width allowed
+#define PWM_SERVO_PULSE_MIN     150       // minimum PWM servo output pulse width allowed
 #define PWM_SERVO_PULSE_MAX     2250      // maximum PWM servo output pulse width allowed
 
 #define RXFAIL_PULSE_MIN        875


### PR DESCRIPTION
The OMP M1 ESC pulse width is between 150μs (motor off) to 335 μs (full throttle) at a rate of 2.6kHz. This PR adds support for this proprietary protocol.
