### PR TITLE
Re-instate check for too large no of rx channels.

### DIFF
--- a/src/main/rx/rx.c
+++ b/src/main/rx/rx.c
@@ -346,10 +346,7 @@ void rxInit(void)
     // Setup source frame RSSI filtering to take averaged values every FRAME_ERR_RESAMPLE_US
     pt1FilterInit(&frameErrFilter, GET_FRAME_ERR_LPF_FREQUENCY(rxConfig()->rssi_src_frame_lpf_period), 1e6f / FRAME_ERR_RESAMPLE_US);
 
-    if ( rxRuntimeState.channelCount > MAX_SUPPORTED_RC_CHANNEL_COUNT)
-      rxChannelCount = MAX_SUPPORTED_RC_CHANNEL_COUNT;
-    else
-      rxChannelCount = rxRuntimeState.channelCount;
+    rxChannelCount = MIN(rxRuntimeState.channelCount, MAX_SUPPORTED_RC_CHANNEL_COUNT);
 }
 
 bool rxIsReceivingSignal(void)

--- a/src/main/rx/rx.c
+++ b/src/main/rx/rx.c
@@ -346,7 +346,10 @@ void rxInit(void)
     // Setup source frame RSSI filtering to take averaged values every FRAME_ERR_RESAMPLE_US
     pt1FilterInit(&frameErrFilter, GET_FRAME_ERR_LPF_FREQUENCY(rxConfig()->rssi_src_frame_lpf_period), 1e6f / FRAME_ERR_RESAMPLE_US);
 
-    rxChannelCount = rxRuntimeState.channelCount;
+    if ( rxRuntimeState.channelCount > MAX_SUPPORTED_RC_CHANNEL_COUNT)
+      rxChannelCount = MAX_SUPPORTED_RC_CHANNEL_COUNT;
+    else
+      rxChannelCount = rxRuntimeState.channelCount;
 }
 
 bool rxIsReceivingSignal(void)


### PR DESCRIPTION
Fixes the problem with buffer over-run when using Rx and Tx with large no of channels. I.e. SRXL2 32 channels.
 
