### PR TITLE
Fix annoying Rx fast boot alarm in latest Spektrum Tx firmware.

### DIFF
--- a/src/main/telemetry/srxl.c
+++ b/src/main/telemetry/srxl.c
@@ -164,11 +164,12 @@ typedef struct
     INT8 dBm_A, // Average signal for A antenna in dBm
     INT8 dBm_B; // Average signal for B antenna in dBm.
     // If only 1 antenna, set B = A
+    UINT16 spare[2]; // Seems to be used as some "Rx fast boot" indicator if non-zero, brown out detection?
 } STRU_TELE_RPM;
 */
 
 #define STRU_TELE_RPM_EMPTY_FIELDS_COUNT 8
-#define STRU_TELE_RPM_EMPTY_FIELDS_VALUE 0xff
+#define STRU_TELE_RPM_EMPTY_FIELDS_VALUE 0
 
 #define SPEKTRUM_RPM_UNUSED 0xffff
 #define SPEKTRUM_TEMP_UNUSED 0x7fff


### PR DESCRIPTION
Latest iX20 firmware and Airware app seems to have a new "Receiver Fast Boot" telemetry alarm, very annoying when powering up Rx. Fixed by clearing some spare fields in the RPM telemetry frame. 
This PR might also be needed in a RF4.2 maintenance release. (As well as BF...) 
/A