### PR TITLE
MPU gyro sample rate fix

### DIFF
--- a/src/main/drivers/accgyro/accgyro.h
+++ b/src/main/drivers/accgyro/accgyro.h
@@ -112,6 +112,8 @@ typedef struct gyroDev_s {
     uint32_t detectedEXTI;
     uint32_t gyroLastEXTI;
     uint32_t gyroSyncEXTI;
+    uint32_t gyroEXTICount;
+    uint32_t gyroEXTIDenom;
     int32_t gyroShortPeriod;
     int32_t gyroDmaMaxDuration;
     busSegment_t segments[2];

--- a/src/main/drivers/accgyro/accgyro_mpu.c
+++ b/src/main/drivers/accgyro/accgyro_mpu.c
@@ -136,6 +136,9 @@ static void mpuIntExtiHandler(extiCallbackRec_t *cb)
 {
     gyroDev_t *gyro = container_of(cb, gyroDev_t, exti);
 
+    // skip specified number of interrupts to keep gyro sampling rate on MPU6500 derivatives
+    if(gyro->gyroEXTICount++ % gyro->gyroEXTIDenom) return;
+
     // Ideally we'd use a timer to capture such information, but unfortunately the port used for EXTI interrupt does
     // not have an associated timer
     uint32_t nowCycles = getCycleCounter();
@@ -491,6 +494,11 @@ void mpuGyroInit(gyroDev_t *gyro)
 uint8_t mpuGyroDLPF(gyroDev_t *gyro)
 {
     uint8_t ret = 0;
+
+    // force gyro to 1k sampling rate and ~180hz lpf
+    if (gyro->gyroRateKHz == GYRO_RATE_1_kHz) {
+        return 1;
+    }
 
     // If gyro is in 32KHz mode then the DLPF bits aren't used
     if (gyro->gyroRateKHz <= GYRO_RATE_8_kHz) {


### PR DESCRIPTION
MPU6500 and derivatives (MPU9250, ICM206xx) ignores sample rate divider if DLPF is set to 0 and triggers EXTI interrupt with 8k/s. There are two solutions for this issue:
1. ability to skip specified number of readings in interrupt handler to achive requested samping rate.
2. force 1k internal sampling rate

both solutions are available, so it is possible to experiment

in gyroSetSampleRate() function
```c
// first solution to get 1k with DLPF=0
gyroRateKHz = GYRO_RATE_8_kHz;
gyroEXTIDenom = 8;

// second solution to get 1k internal sampling rate
gyroRateKHz = GYRO_RATE_1_kHz;
```

MPU6000 is not affected