### PR TITLE
Horizon Mode Inverted Self-Level

### DIFF
--- a/src/main/flight/imu.c
+++ b/src/main/flight/imu.c
@@ -634,3 +634,9 @@ bool isUpright(void)
     return true;
 #endif
 }
+
+bool isUpsidedown(void)
+{
+  return !sensors(SENSOR_ACC) || (attitudeIsEstablished && getCosTiltAngle() < 0);
+}
+

--- a/src/main/flight/imu.h
+++ b/src/main/flight/imu.h
@@ -83,3 +83,4 @@ void imuSetHasNewData(uint32_t dt);
 
 bool shouldInitializeGPSHeading(void);
 bool isUpright(void);
+bool isUpsidedown(void);

--- a/src/main/flight/trainer.c
+++ b/src/main/flight/trainer.c
@@ -104,12 +104,23 @@ float acroTrainerApply(int axis, float setPoint)
     if (acroTrainer.Active && (axis == FD_ROLL || axis == FD_PITCH))
     {
         const rollAndPitchTrims_t *angleTrim = &accelerometerConfig()->accelerometerTrims;
-        const float currentAngle = (attitude.raw[axis] - angleTrim->raw[axis]) / 10.0f;
+        float currentAngle = (attitude.raw[axis] - angleTrim->raw[axis]) / 10.0f;
         const sign_t angleSign = Sign(currentAngle);
         const sign_t setpointSign = Sign(setPoint);
         float projectedAngle = 0;
         bool resetAxis = false;
 
+        if ( isUpsidedown() && FLIGHT_MODE(HORIZON_MODE) ){
+            switch (axis) {
+              case FD_PITCH:
+                currentAngle *= -1;
+                break;
+              case FD_ROLL:
+                currentAngle = Sign(currentAngle) * 180;
+                break;
+             }
+        }
+  
         // stick has reversed - stop limiting
         if ((acroTrainer.AxisState[axis] != 0) && (acroTrainer.AxisState[axis] != setpointSign)) {  // stick has reversed - stop limiting
             acroTrainer.AxisState[axis] = 0;


### PR DESCRIPTION
Horizon mode modification for the helicopter to self-level when Inverted in addition to the typical upright self-level operation. This makes it easier for new pilots to lean inverted flight.

This needs testing as I could not get the DEVEL branch to run with my snapshot version of the configurator.