### PR TITLE
Fixed TTA when main rotor direction is CCW

### DIFF
--- a/src/main/flight/governor.c
+++ b/src/main/flight/governor.c
@@ -448,7 +448,9 @@ static void govUpdateData(void)
     if (mixerMotorizedTail() && gov.TTAGain > 0) {
         float YAW = mixerGetInput(MIXER_IN_STABILIZED_YAW);
         float TTA = filterApply(&gov.TTAFilter, YAW) * getSpoolUpRatio() * gov.TTAGain;
-        gov.TTAAdd = constrainf(TTA, 0, gov.TTALimit);
+        gov.TTAAdd = mixerCwMainRotor()
+            ? constrainf(TTA, 0, gov.TTALimit)
+            : -constrainf(TTA, -gov.TTALimit, 0);
     }
     else {
         gov.TTAAdd = 0.0f;
@@ -980,7 +982,7 @@ void governorInitProfile(const pidProfile_t *pidProfile)
         gov.Kd = pidProfile->governor.d_gain / 1000.0f;
         gov.Kf = pidProfile->governor.f_gain / 100.0f;
 
-        gov.TTAGain   = mixerRotationSign() * pidProfile->governor.tta_gain / -125.0f;
+        gov.TTAGain   = pidProfile->governor.tta_gain / 125.0f;
         gov.TTALimit  = pidProfile->governor.tta_limit / 100.0f;
 
         if (gov.mode >= GM_STANDARD)

--- a/src/main/flight/mixer.h
+++ b/src/main/flight/mixer.h
@@ -237,9 +237,14 @@ static inline void mixerSaturateMotorOutput(uint8_t index)
     mixerSaturateOutput(index + MIXER_MOTOR_OFFSET);
 }
 
+static inline bool mixerCwMainRotor()
+{
+    return mixerConfig()->main_rotor_dir == DIR_CW;
+}
+
 static inline int mixerRotationSign()
 {
-    return (mixerConfig()->main_rotor_dir == DIR_CW) ? -1 : 1;
+    return mixerCwMainRotor() ? -1 : 1;
 }
 
 static inline bool mixerMotorizedTail(void)


### PR DESCRIPTION
TTA didn't do anything when the main rotor direction was set to CCW. This PR fixes that. TTA now works with CW and CCW main rotor directions.