### PR TITLE
feat: added support for lua servo page  

### DIFF
--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -1103,7 +1103,9 @@ static bool mspProcessOutCommand(int16_t cmdMSP, sbuf_t *dst)
         break;
 
     case MSP_SERVO_CONFIGURATIONS:
-        for (int i = 0; i < MAX_SUPPORTED_SERVOS; i++) {
+        sbufWriteU8(dst, getServoCount());
+
+        for (int i = 0; i < getServoCount(); i++) {
             sbufWriteU16(dst, servoParams(i)->mid);
             sbufWriteU16(dst, servoParams(i)->min);
             sbufWriteU16(dst, servoParams(i)->max);


### PR DESCRIPTION
For the LUA servo page I need the servo count. Since stacking MSP requests in LUA isn't supported right now, I simply added it to MSP_SERVO_CONFIGURATIONS. It also makes it slightly more efficient since unused servo data won't be transmitted.