### PR TITLE
Angle Mode setpoint input arg was lost. 

### DIFF
--- a/src/main/flight/leveling.c
+++ b/src/main/flight/leveling.c
@@ -174,7 +174,7 @@ float angleModeApply(int axis, float pidSetpoint)
         if (!isAirborne())
             errorAngle *= 0.25f;
 
-        pidSetpoint = errorAngle * level.Gain;
+        pidSetpoint += errorAngle * level.Gain;
     }
 
     return pidSetpoint;


### PR DESCRIPTION
Noticed different ele/ail stick feel around center with RF2-RC1. In angle mode very unresponsive, horizon mode more normal and like acro mode. In RF1 there was no such difference. Turns out the angleModeApply function overwrites the input arg pidSetpoint while horizonModeApply does not.  Angle and Horizon modes now handles setpoint arg the same way. 
