### PR TITLE
OpenYGE - fix: address possible buffer underflow condition, add 2nd paranoid frame length validation …

### DIFF
--- a/src/main/sensors/esc_sensor.c
+++ b/src/main/sensors/esc_sensor.c
@@ -1569,7 +1569,7 @@ enum {
 static timeMs_t oygeRampTimer = 0;
 static uint32_t oygeFrameTimestamp = 0;
 static uint16_t oygeFramePeriod = OPENYGE_FRAME_PERIOD_INITIAL;
-static volatile uint8_t oygeFrameLength = OPENYGE_FRAME_MIN_LENGTH;
+static volatile uint8_t oygeFrameLength = 0;
 
 
 static uint16_t oygeCalculateCRC16_CCITT(const uint8_t *ptr, size_t len)
@@ -1622,11 +1622,13 @@ static FAST_CODE void oygeDataReceive(uint16_t c, void *data)
         else if (readBytes == 4) {
             // frame length
             // protect against buffer overflow
-            if (c > TELEMETRY_BUFFER_SIZE)
+            if (c < OPENYGE_FRAME_MIN_LENGTH || c > TELEMETRY_BUFFER_SIZE) {
                 oygeFrameSyncError();
-            else
+            }
+            else {
+                oygeFrameLength = c;
                 syncCount++;
-            oygeFrameLength = c;
+            }
         }
     }
 }
@@ -1634,7 +1636,7 @@ static FAST_CODE void oygeDataReceive(uint16_t c, void *data)
 static void oygeStartTelemetryFrame(timeMs_t currentTimeMs)
 {
     readBytes = 0;
-
+    oygeFrameLength = OPENYGE_FRAME_MIN_LENGTH;
     oygeFrameTimestamp = currentTimeMs;
 }
 
@@ -1644,9 +1646,15 @@ static uint8_t oygeDecodeTelemetryFrame(void)
     if (readBytes < oygeFrameLength)
         return OPENYGE_FRAME_PENDING;
 
+    // paranoid length check
+    uint8_t len = buffer[3];
+    if (len < OPENYGE_FRAME_MIN_LENGTH || len > TELEMETRY_BUFFER_SIZE) {
+        totalCrcErrorCount++;
+        return OPENYGE_FRAME_FAILED;
+    }
     // verify CRC16 checksum
-    uint16_t crc = buffer[oygeFrameLength - 1] << 8 | buffer[oygeFrameLength - 2];
-    if (oygeCalculateCRC16_CCITT(buffer, oygeFrameLength - 2) != crc) {
+    uint16_t crc = buffer[len - 1] << 8 | buffer[len - 2];
+    if (oygeCalculateCRC16_CCITT(buffer, len - 2) != crc) {
         totalCrcErrorCount++;
         return OPENYGE_FRAME_FAILED;
     }


### PR DESCRIPTION
…outside ISR/callback.

Discovered while testing a derivative branch it was observed FC became unresponsive while making MSP updates w/ RF2 LUA or RF configurator. Issue was intermittent.

Cause:
- inadequate validation of received length member of header
- length is checked against buffer size to avoid overflow but not against valid minimum
- buffer underrun when trying to extract CRC from packet if length < 2

Fix:
- added min length validation  to receive ISR
- added secondary paranoid check prior to extracting CRC
- harden oygeFrameLength, always reset minimum at start of frame

Note: we were not able to reproduce this issue with RC1 but this code vulnerable without this fix