### PR TITLE
Fix for current FW Kontronik ESCs - verified Kolibri v3.0/v3.5, Kosmik 200 HV v4.17

### DIFF
--- a/src/main/sensors/esc_sensor.c
+++ b/src/main/sensors/esc_sensor.c
@@ -1008,7 +1008,8 @@ static void uncSensorProcess(timeUs_t currentTimeUs)
  *  28-31:      Error Flags
  *     32:      Operational condition
  *     33:      Timing 0..30
- *  34-37:      CRC32
+ *  34-35:      Reserved
+ *  36-39:      CRC32
  *
  */
 

--- a/src/main/sensors/esc_sensor.c
+++ b/src/main/sensors/esc_sensor.c
@@ -1049,7 +1049,7 @@ static bool processKontronikTelemetryStream(uint8_t dataByte)
         else
             syncCount++;
     }
-    else if (readBytes == 38) {
+    else if (readBytes == 40) {
         readBytes = 0;
         return true;
     }
@@ -1062,9 +1062,9 @@ static void kontronikSensorProcess(timeUs_t currentTimeUs)
     // check for any available bytes in the rx buffer
     while (serialRxBytesWaiting(escSensorPort)) {
         if (processKontronikTelemetryStream(serialRead(escSensorPort))) {
-            uint32_t crc = buffer[37] << 24 | buffer[36] << 16 | buffer[35] << 8 | buffer[34];
+            uint32_t crc = buffer[39] << 24 | buffer[38] << 16 | buffer[37] << 8 | buffer[36];
 
-            if (calculateCRC32(buffer, 34) == crc) {
+            if (calculateCRC32(buffer, 36) == crc) {
                 uint32_t rpm = buffer[7] << 24 | buffer[6] << 16 | buffer[5] << 8 | buffer[4];
                 uint16_t pwm = buffer[23] << 8 | buffer[22];
                 uint16_t voltage = buffer[9] << 8 | buffer[8];


### PR DESCRIPTION
Current ESC FW for the Jive (v1.17) / Kolibri (3.0 - 3.5) / Kosmik (v4.17) are 40 byte data + 44 byte info.
JivePro/Kosmic v*.13 were different 38 byte w/ 32 byte payload, 2 extra bytes and 4 byte CRC, based on release notes it is likely that the *.14 versions switched to the current 40 byte packet but this could not be verified due to lack of test subjects.

This is a simple fix to support modern 40 byte packet - a more elaborate scheme to support older controllers is outside of RF RC scope, possible future consideration.

Kosmik 250 HV-I could not be properly verified due to what appears to be an unrelated defect - versions 1.17 - 1.25 appeared to produce correct 40 byte but broken frames.