### PR TITLE
Auto detection fix for Kontronik ESCs - verified Kolibri v3.0/v3.5, Kosmik 200 HV v4.17, JivePro 120 HV v1.13

### DIFF
--- a/src/main/sensors/esc_sensor.c
+++ b/src/main/sensors/esc_sensor.c
@@ -1012,6 +1012,12 @@ static void uncSensorProcess(timeUs_t currentTimeUs)
  *  36-39:      CRC32
  *
  */
+#define KON_FRAME_LENGTH                40
+#define KON_FRAME_LENGTH_LEGACY         38
+#define KON_CRC_LENGTH                  4
+
+static uint8_t kontronikPacketLength    = 0;    // 40 or 38 byte
+static uint8_t kontronikCrcExclude      = 0;    // 0 or 2
 
 static uint32_t calculateCRC32(const uint8_t *ptr, size_t len)
 {
@@ -1024,6 +1030,11 @@ static uint32_t calculateCRC32(const uint8_t *ptr, size_t len)
     }
 
     return ~crc;
+}
+
+static uint32_t kontronikDecodeCRC(uint8_t index)
+{
+    return buffer[index + 3] << 24 | buffer[index + 2] << 16 | buffer[index + 1] << 8 | buffer[index];
 }
 
 static bool processKontronikTelemetryStream(uint8_t dataByte)
@@ -1050,7 +1061,36 @@ static bool processKontronikTelemetryStream(uint8_t dataByte)
         else
             syncCount++;
     }
-    else if (readBytes == 40) {
+    else if (readBytes == kontronikPacketLength) {
+        readBytes = 0;
+        return true;
+    }
+    else if (kontronikPacketLength == 0 && readBytes == KON_FRAME_LENGTH_LEGACY) {
+        // auto detect legacy 38 byte packet...
+        uint32_t crc = kontronikDecodeCRC(KON_FRAME_LENGTH_LEGACY - KON_CRC_LENGTH);
+        if (calculateCRC32(buffer, KON_FRAME_LENGTH_LEGACY - 2 - KON_CRC_LENGTH) == crc) {
+            // ...w/ 32 byte payload (2 bytes excluded)
+            kontronikPacketLength = KON_FRAME_LENGTH_LEGACY;
+            kontronikCrcExclude = 2;
+            readBytes = 0;
+            return true;
+        }
+        else if (calculateCRC32(buffer, KON_FRAME_LENGTH_LEGACY - KON_CRC_LENGTH) == crc) {
+            // ...w/ 34 byte payload
+            kontronikPacketLength = KON_FRAME_LENGTH_LEGACY;
+            kontronikCrcExclude = 0;
+            readBytes = 0;
+            return true;
+        }
+    }
+    else if (kontronikPacketLength == 0 && readBytes == KON_FRAME_LENGTH) {
+        // auto detect 40 byte packet...
+        uint32_t crc = kontronikDecodeCRC(40 - KON_CRC_LENGTH);
+        if (calculateCRC32(buffer, KON_FRAME_LENGTH - KON_CRC_LENGTH) == crc) {
+            // ...w/ 36 byte payload
+            kontronikPacketLength = KON_FRAME_LENGTH;
+            kontronikCrcExclude = 0;
+        }
         readBytes = 0;
         return true;
     }
@@ -1063,9 +1103,8 @@ static void kontronikSensorProcess(timeUs_t currentTimeUs)
     // check for any available bytes in the rx buffer
     while (serialRxBytesWaiting(escSensorPort)) {
         if (processKontronikTelemetryStream(serialRead(escSensorPort))) {
-            uint32_t crc = buffer[39] << 24 | buffer[38] << 16 | buffer[37] << 8 | buffer[36];
-
-            if (calculateCRC32(buffer, 36) == crc) {
+            uint32_t crc = kontronikDecodeCRC(kontronikPacketLength - KON_CRC_LENGTH);
+            if (calculateCRC32(buffer, kontronikPacketLength - kontronikCrcExclude - KON_CRC_LENGTH) == crc) {
                 uint32_t rpm = buffer[7] << 24 | buffer[6] << 16 | buffer[5] << 8 | buffer[4];
                 uint16_t pwm = buffer[23] << 8 | buffer[22];
                 uint16_t voltage = buffer[9] << 8 | buffer[8];

--- a/src/main/sensors/esc_sensor.c
+++ b/src/main/sensors/esc_sensor.c
@@ -1008,7 +1008,8 @@ static void uncSensorProcess(timeUs_t currentTimeUs)
  *  28-31:      Error Flags
  *     32:      Operational condition
  *     33:      Timing 0..30
- *  34-37:      CRC32
+ *  34-35:      Reserved
+ *  36-39:      CRC32
  *
  */
 

--- a/src/main/sensors/esc_sensor.c
+++ b/src/main/sensors/esc_sensor.c
@@ -1049,7 +1049,7 @@ static bool processKontronikTelemetryStream(uint8_t dataByte)
         else
             syncCount++;
     }
-    else if (readBytes == 38) {
+    else if (readBytes == 40) {
         readBytes = 0;
         return true;
     }
@@ -1062,9 +1062,9 @@ static void kontronikSensorProcess(timeUs_t currentTimeUs)
     // check for any available bytes in the rx buffer
     while (serialRxBytesWaiting(escSensorPort)) {
         if (processKontronikTelemetryStream(serialRead(escSensorPort))) {
-            uint32_t crc = buffer[37] << 24 | buffer[36] << 16 | buffer[35] << 8 | buffer[34];
+            uint32_t crc = buffer[39] << 24 | buffer[38] << 16 | buffer[37] << 8 | buffer[36];
 
-            if (calculateCRC32(buffer, 34) == crc) {
+            if (calculateCRC32(buffer, 36) == crc) {
                 uint32_t rpm = buffer[7] << 24 | buffer[6] << 16 | buffer[5] << 8 | buffer[4];
                 uint16_t pwm = buffer[23] << 8 | buffer[22];
                 uint16_t voltage = buffer[9] << 8 | buffer[8];


### PR DESCRIPTION
Enhancement to https://github.com/rotorflight/rotorflight-firmware/pull/98 to handle legacy and current Kontronik  ESCs

- assume length unknown
- while length unknown
- test at 38 bytes for valid CRC for 32 or 34 byte payload, set expected length == 38 (and crc exclusion) if yes
- test at 40 bytes for valid CRC, set expected length = 40 if yes

- use length determined for all subsequent packets