### PR TITLE
CMS bugfix and cleanup.

### DIFF
--- a/src/main/cms/cms_menu_imu.c
+++ b/src/main/cms/cms_menu_imu.c
@@ -151,6 +151,8 @@ static const void *cmsx_profileIndexOnChange(displayPort_t *displayPort, const v
 
     pidProfileIndex = tmpPidProfileIndex - 1;
     changePidProfile(pidProfileIndex);
+    pidProfile = pidProfilesMutable(pidProfileIndex);
+    setProfileIndexString(pidProfileIndexString, pidProfileIndex, pidProfile->profileName);
 
     return NULL;
 }
@@ -162,6 +164,8 @@ static const void *cmsx_rateProfileIndexOnChange(displayPort_t *displayPort, con
 
     rateProfileIndex = tmpRateProfileIndex - 1;
     changeControlRateProfile(rateProfileIndex);
+    memcpy(&rateProfile, controlRateProfiles(rateProfileIndex), sizeof(controlRateConfig_t));
+    setProfileIndexString(rateProfileIndexString, rateProfileIndex, controlRateProfilesMutable(rateProfileIndex)->profileName);
 
     return NULL;
 }

--- a/src/main/cms/cms_menu_imu.c
+++ b/src/main/cms/cms_menu_imu.c
@@ -272,20 +272,20 @@ static const OSD_Entry cmsx_menuRateProfileEntries[] =
 {
     { "-- RATE --", OME_Label, NULL, rateProfileIndexString },
 
-    { "RC R RATE",   OME_FLOAT,  NULL, &(OSD_FLOAT_t) { &rateProfile.rcRates[FD_ROLL],    1, CONTROL_RATE_CONFIG_RC_RATES_MAX, 1, 10 } },
-    { "RC P RATE",   OME_FLOAT,  NULL, &(OSD_FLOAT_t) { &rateProfile.rcRates[FD_PITCH],    1, CONTROL_RATE_CONFIG_RC_RATES_MAX, 1, 10 } },
-    { "RC Y RATE",   OME_FLOAT,  NULL, &(OSD_FLOAT_t) { &rateProfile.rcRates[FD_YAW], 1, CONTROL_RATE_CONFIG_RC_RATES_MAX, 1, 10 } },
+    { "RC R RATE",   OME_UINT8,  NULL, &(OSD_UINT8_t) { &rateProfile.rcRates[FD_ROLL],  1, CONTROL_RATE_CONFIG_RC_RATES_MAX, 1 }},
+    { "RC P RATE",   OME_UINT8,  NULL, &(OSD_UINT8_t) { &rateProfile.rcRates[FD_PITCH], 1, CONTROL_RATE_CONFIG_RC_RATES_MAX, 1}},
+    { "RC Y RATE",   OME_UINT8,  NULL, &(OSD_UINT8_t) { &rateProfile.rcRates[FD_YAW],   1, CONTROL_RATE_CONFIG_RC_RATES_MAX, 1 }},
 
-    { "ROLL SUPER",  OME_FLOAT,  NULL, &(OSD_FLOAT_t) { &rateProfile.rates[FD_ROLL],   0, CONTROL_RATE_CONFIG_SUPER_RATE_MAX, 1, 10 } },
-    { "PITCH SUPER", OME_FLOAT,  NULL, &(OSD_FLOAT_t) { &rateProfile.rates[FD_PITCH],   0, CONTROL_RATE_CONFIG_SUPER_RATE_MAX, 1, 10 } },
-    { "YAW SUPER",   OME_FLOAT,  NULL, &(OSD_FLOAT_t) { &rateProfile.rates[FD_YAW],   0, CONTROL_RATE_CONFIG_SUPER_RATE_MAX, 1, 10 } },
+    { "ROLL SUPER",  OME_UINT8,  NULL, &(OSD_UINT8_t) { &rateProfile.rates[FD_ROLL],    0, CONTROL_RATE_CONFIG_SUPER_RATE_MAX, 1 }},
+    { "PITCH SUPER", OME_UINT8,  NULL, &(OSD_UINT8_t) { &rateProfile.rates[FD_PITCH],   0, CONTROL_RATE_CONFIG_SUPER_RATE_MAX, 1 }},
+    { "YAW SUPER",   OME_UINT8,  NULL, &(OSD_UINT8_t) { &rateProfile.rates[FD_YAW],     0, CONTROL_RATE_CONFIG_SUPER_RATE_MAX, 1 }},
 
-    { "RC R EXPO",   OME_FLOAT,  NULL, &(OSD_FLOAT_t) { &rateProfile.rcExpo[FD_ROLL],    0, 100, 1, 10 } },
-    { "RC P EXPO",   OME_FLOAT,  NULL, &(OSD_FLOAT_t) { &rateProfile.rcExpo[FD_PITCH],    0, 100, 1, 10 } },
-    { "RC Y EXPO",   OME_FLOAT,  NULL, &(OSD_FLOAT_t) { &rateProfile.rcExpo[FD_YAW], 0, 100, 1, 10 } },
+    { "RC R EXPO",   OME_UINT8,  NULL, &(OSD_UINT8_t) { &rateProfile.rcExpo[FD_ROLL],   0, 100, 1 }},
+    { "RC P EXPO",   OME_UINT8,  NULL, &(OSD_UINT8_t) { &rateProfile.rcExpo[FD_PITCH],  0, 100, 1 }},
+    { "RC Y EXPO",   OME_UINT8,  NULL, &(OSD_UINT8_t) { &rateProfile.rcExpo[FD_YAW],    0, 100, 1 }},
 
-    { "ROLL LVL EXPO",  OME_FLOAT, NULL, &(OSD_FLOAT_t) { &rateProfile.levelExpo[FD_ROLL],  0, 100, 1, 10 } },
-    { "PITCH LVL EXPO", OME_FLOAT, NULL, &(OSD_FLOAT_t) { &rateProfile.levelExpo[FD_PITCH], 0, 100, 1, 10 } },
+    { "ROLL LVL EXPO",  OME_UINT8, NULL, &(OSD_UINT8_t) { &rateProfile.levelExpo[FD_ROLL],  0, 100, 1 }},
+    { "PITCH LVL EXPO", OME_UINT8, NULL, &(OSD_UINT8_t) { &rateProfile.levelExpo[FD_PITCH], 0, 100, 1 }},
 
     { "BACK", OME_Back, NULL, NULL },
     { NULL, OME_END, NULL, NULL}

--- a/src/main/cms/cms_menu_imu.c
+++ b/src/main/cms/cms_menu_imu.c
@@ -114,6 +114,15 @@ static void cmsx_initPidProfile()
     setProfileIndexString(pidProfileIndexString, pidProfileIndex, pidProfile->profileName);
 }
 
+void cmsx_updateCurrentPidProfile()
+{
+  // Update current active PID profile only if it is the same as the one CMS has been working on 
+  if (pidProfileIndex == getCurrentPidProfileIndex() ) {
+    pidInitProfile(currentPidProfile);
+  }
+}
+
+
 static void cmsx_initRateProfile()
 {
     rateProfileIndex = getCurrentControlRateProfileIndex();
@@ -138,7 +147,7 @@ static const void *cmsx_menuImu_onExit(displayPort_t *pDisp, const OSD_Entry *se
     UNUSED(pDisp);
     UNUSED(self);
 
-    changePidProfile(pidProfileIndex);
+    cmsx_updateCurrentPidProfile();
     changeControlRateProfile(rateProfileIndex);
 
     return NULL;
@@ -205,8 +214,8 @@ static const void *cmsx_PidWriteback(displayPort_t *pDisp, const OSD_Entry *self
         pidProfile->pid[i].O = tempPidO[i];
         pidProfile->pid[i].B = tempPidB[i];
     }
-    changePidProfile(pidProfileIndex);
 
+    cmsx_updateCurrentPidProfile();
     return NULL;
 }
 
@@ -324,6 +333,7 @@ static const void *cmsx_profileYawOnEnter(displayPort_t *pDisp)
     cmsx_yawCollectiveFF =   pidProfile->yaw_collective_ff_gain;
     cmsx_yawTTA =            pidProfile->governor.tta_gain;
     cmsx_yawPrecompCutoff =  pidProfile->yaw_precomp_cutoff;
+
     return NULL;
 }
 
@@ -339,7 +349,7 @@ static const void *cmsx_profileYawOnExit(displayPort_t *pDisp, const OSD_Entry *
     pidProfile->governor.tta_gain =      cmsx_yawTTA;
     pidProfile->yaw_precomp_cutoff =     cmsx_yawPrecompCutoff;
 
-    changePidProfile(pidProfileIndex);
+    cmsx_updateCurrentPidProfile();
     return NULL;
 }
 
@@ -402,7 +412,7 @@ static const void *cmsx_profileCtrlOnExit(displayPort_t *pDisp, const OSD_Entry 
       pidProfile->iterm_relax_cutoff[i] = cmsx_pidItermRelaxCutoff[i];
     }
 
-    changePidProfile(pidProfileIndex);
+    cmsx_updateCurrentPidProfile();
     return NULL;
 }
 
@@ -463,7 +473,7 @@ static const void *cmsx_profileCtrlBwOnExit(displayPort_t *pDisp, const OSD_Entr
       pidProfile->bterm_cutoff[i] = cmsx_pidBCutoff[i];
     }
 
-    changePidProfile(pidProfileIndex);
+    cmsx_updateCurrentPidProfile();
     return NULL;
 }
 
@@ -525,7 +535,7 @@ static const void *cmsx_profileLevelOnExit(displayPort_t *pDisp, const OSD_Entry
     pidProfile->horizon.level_strength = cmsx_horizonStrength;
     pidProfile->horizon.transition =     cmsx_horizonTransition;
 
-    changePidProfile(pidProfileIndex);
+    cmsx_updateCurrentPidProfile();
     return NULL;
 }
 
@@ -589,7 +599,7 @@ static const void *cmsx_profileRescueOnExit(displayPort_t *pDisp, const OSD_Entr
     pidProfile->rescue.level_gain =         cmsx_rescueLevelGain;
     pidProfile->rescue.flip_gain =          cmsx_rescueFlipGain;
 
-    changePidProfile(pidProfileIndex);
+    cmsx_updateCurrentPidProfile();
     return NULL;
 }
 
@@ -653,7 +663,7 @@ static const void *cmsx_profileGovernorOnExit(displayPort_t *pDisp, const OSD_En
     pidProfile->governor.d_gain =    cmsx_govD;
     pidProfile->governor.f_gain =    cmsx_govF;
 
-    changePidProfile(pidProfileIndex);
+    cmsx_updateCurrentPidProfile();
     return NULL;
 }
 

--- a/src/main/cms/cms_menu_imu.c
+++ b/src/main/cms/cms_menu_imu.c
@@ -189,7 +189,6 @@ static const void *cmsx_PidOnEnter(displayPort_t *pDisp)
     UNUSED(pDisp);
 
     cmsx_PidRead();
-
     return NULL;
 }
 
@@ -206,7 +205,7 @@ static const void *cmsx_PidWriteback(displayPort_t *pDisp, const OSD_Entry *self
         pidProfile->pid[i].O = tempPidO[i];
         pidProfile->pid[i].B = tempPidB[i];
     }
-    pidInitProfile(pidProfile);
+    changePidProfile(pidProfileIndex);
 
     return NULL;
 }
@@ -340,8 +339,7 @@ static const void *cmsx_profileYawOnExit(displayPort_t *pDisp, const OSD_Entry *
     pidProfile->governor.tta_gain =      cmsx_yawTTA;
     pidProfile->yaw_precomp_cutoff =     cmsx_yawPrecompCutoff;
 
-    pidInitProfile(pidProfile);
-
+    changePidProfile(pidProfileIndex);
     return NULL;
 }
 
@@ -404,8 +402,7 @@ static const void *cmsx_profileCtrlOnExit(displayPort_t *pDisp, const OSD_Entry 
       pidProfile->iterm_relax_cutoff[i] = cmsx_pidItermRelaxCutoff[i];
     }
 
-    pidInitProfile(pidProfile);
-
+    changePidProfile(pidProfileIndex);
     return NULL;
 }
 
@@ -466,8 +463,7 @@ static const void *cmsx_profileCtrlBwOnExit(displayPort_t *pDisp, const OSD_Entr
       pidProfile->bterm_cutoff[i] = cmsx_pidBCutoff[i];
     }
 
-    pidInitProfile(pidProfile);
-
+    changePidProfile(pidProfileIndex);
     return NULL;
 }
 
@@ -529,8 +525,7 @@ static const void *cmsx_profileLevelOnExit(displayPort_t *pDisp, const OSD_Entry
     pidProfile->horizon.level_strength = cmsx_horizonStrength;
     pidProfile->horizon.transition =     cmsx_horizonTransition;
 
-    pidInitProfile(pidProfile);
-
+    changePidProfile(pidProfileIndex);
     return NULL;
 }
 
@@ -594,8 +589,7 @@ static const void *cmsx_profileRescueOnExit(displayPort_t *pDisp, const OSD_Entr
     pidProfile->rescue.level_gain =         cmsx_rescueLevelGain;
     pidProfile->rescue.flip_gain =          cmsx_rescueFlipGain;
 
-    pidInitProfile(pidProfile);
-
+    changePidProfile(pidProfileIndex);
     return NULL;
 }
 
@@ -659,8 +653,7 @@ static const void *cmsx_profileGovernorOnExit(displayPort_t *pDisp, const OSD_En
     pidProfile->governor.d_gain =    cmsx_govD;
     pidProfile->governor.f_gain =    cmsx_govF;
 
-    pidInitProfile(pidProfile);
-
+    changePidProfile(pidProfileIndex);
     return NULL;
 }
 


### PR DESCRIPTION
Bugfix profile handling. Was a mixed use of global config items, local statics and dynamics. Profiles did get out of sync if external changes was made, from RFC or via adjustments. Now only picks up current profiles on main profile menu entry, and sticks to that until exit.

Menu string changes for a bit more clarity:
CYCL GAIN - CY XC GAIN etc, to indicate "Cross Coupling" (XC). 
Use TAIL as in RFC, not YAW, in menu heading. 
