### PR TITLE
Adjust function should not confirm pid profile change with a single beep.

### DIFF
--- a/src/main/fc/rc_adjustments.c
+++ b/src/main/fc/rc_adjustments.c
@@ -687,7 +687,11 @@ void processRcAdjustments(void)
                     updateAdjustmentData(adjFunc, adjval);
                     blackboxAdjustmentEvent(adjFunc, adjval);
 
-                    beeperConfirmationBeeps(1);
+                    // PID profile change does it's own confirmation, no of beeps eq profile no,
+                    // a single beep here will kill that.
+                    if (adjFunc != ADJUSTMENT_PID_PROFILE) {
+                      beeperConfirmationBeeps(1);
+                    }
                     setConfigDirty();
 
                     adjState->deadTime = now + REPEAT_DELAY;


### PR DESCRIPTION
There is a beeper conflict with adj-function and the pid profile change function.  
PID change will try to confirm profile number with a number of beeps, but the adj function overrides that with just a single beep.
This may be a crude quick fix, another options would be to let the adj function use the adj value for beep confirmation, if value is not too large. Currently adj function confirms everything with just a single beep.
