### PR TITLE
hd - pl5 - fix: missing call to updateConsumption(...)

### DIFF
--- a/src/main/sensors/esc_sensor.c
+++ b/src/main/sensors/esc_sensor.c
@@ -1746,6 +1746,14 @@ static bool pl5Decode(timeUs_t currentTimeUs)
     }
 }
 
+static bool pl5Crank(timeUs_t currentTimeUs)
+{
+    // Update consumption on each cycle vs each frame in decode
+    updateConsumption(currentTimeUs);
+
+    return true;
+}
+
 static int8_t pl5Accept(uint16_t c)
 {
     if (readBytes == 1) {
@@ -1797,6 +1805,7 @@ static serialReceiveCallbackPtr pl5SensorInit(bool bidirectional)
     rrfsmMinFrameLength = PL5_MIN_FRAME_LENGTH;
     rrfsmAccept = pl5Accept;
     rrfsmDecode = pl5Decode;
+    rrfsmCrank = pl5Crank;
 
     paramSig = PL5_PARAM_SIG;
 


### PR DESCRIPTION
Issue:
Calls to updateConsumption(...) required for FC calculated mah consumption for ESC's that don't include consumption in telemetry data e.g. HW5. This call was missed when HW5 was refactored for bidir / forward programming.

Solution:
Call on RRFSM crank - (escSensorProcess frequency, as before)