### PR TITLE
Refactor SRXL telemetry Textgen and CMS displayport.

### DIFF
--- a/src/main/io/displayport_srxl.c
+++ b/src/main/io/displayport_srxl.c
@@ -69,8 +69,8 @@ static int srxlWriteString(displayPort_t *displayPort, uint8_t col, uint8_t row,
 static int srxlClearScreen(displayPort_t *displayPort, displayClearOption_e options)
 {
     UNUSED(options);
-    for (int row = 0; row < SPEKTRUM_SRXL_TEXTGEN_BUFFER_ROWS; row++) {
-        for (int col= 0; col < SPEKTRUM_SRXL_TEXTGEN_BUFFER_COLS; col++) {
+    for (int row = 0; row < SPEKTRUM_SRXL_TEXTGEN_ROWS; row++) {
+        for (int col= 0; col < SPEKTRUM_SRXL_TEXTGEN_COLS; col++) {
             srxlWriteChar(displayPort, col, row, DISPLAYPORT_ATTR_NONE, ' ');
         }
     }
@@ -147,8 +147,8 @@ static displayPort_t *displayPortSrxlInit()
 {
     srxlDisplayPort.device = NULL;
     displayInit(&srxlDisplayPort, &srxlVTable, DISPLAYPORT_DEVICE_TYPE_SRXL);
-    srxlDisplayPort.rows = SPEKTRUM_SRXL_TEXTGEN_BUFFER_ROWS;
-    srxlDisplayPort.cols = SPEKTRUM_SRXL_TEXTGEN_BUFFER_COLS;
+    srxlDisplayPort.rows = SPEKTRUM_SRXL_TEXTGEN_ROWS;
+    srxlDisplayPort.cols = SPEKTRUM_SRXL_TEXTGEN_COLS;
 
     return &srxlDisplayPort;
 }

--- a/src/main/telemetry/srxl.c
+++ b/src/main/telemetry/srxl.c
@@ -460,8 +460,6 @@ bool srxlFrameFlightPackCurrent(sbuf_t *dst, timeUs_t currentTimeUs)
 // Betaflight CMS using Spektrum Tx telemetry TEXT_GEN sensor as display.
 
 #define SPEKTRUM_SRXL_DEVICE_TEXTGEN (0x0C)     // Text Generator
-#define SPEKTRUM_SRXL_DEVICE_TEXTGEN_ROWS (9)   // Text Generator ROWS
-#define SPEKTRUM_SRXL_DEVICE_TEXTGEN_COLS (13)  // Text Generator COLS
 
 /*
 typedef struct
@@ -473,19 +471,14 @@ typedef struct
 } STRU_SPEKTRUM_SRXL_TEXTGEN;
 */
 
-#if ( SPEKTRUM_SRXL_TEXTGEN_BUFFER_COLS > SPEKTRUM_SRXL_DEVICE_TEXTGEN_COLS )
-static char srxlTextBuff[SPEKTRUM_SRXL_TEXTGEN_BUFFER_ROWS][SPEKTRUM_SRXL_TEXTGEN_BUFFER_COLS];
-static bool lineSent[SPEKTRUM_SRXL_TEXTGEN_BUFFER_ROWS];
-#else
-static char srxlTextBuff[SPEKTRUM_SRXL_DEVICE_TEXTGEN_ROWS][SPEKTRUM_SRXL_DEVICE_TEXTGEN_COLS];
-static bool lineSent[SPEKTRUM_SRXL_DEVICE_TEXTGEN_ROWS];
-#endif
+static char srxlTextBuff[SPEKTRUM_SRXL_TEXTGEN_ROWS][SPEKTRUM_SRXL_TEXTGEN_COLS];
+static bool lineSent[SPEKTRUM_SRXL_TEXTGEN_ROWS];
 
 //**************************************************************************
 // API Running in external client task context. E.g. in the CMS task
 int spektrumTmTextGenPutChar(uint8_t col, uint8_t row, char c)
 {
-    if (row < SPEKTRUM_SRXL_TEXTGEN_BUFFER_ROWS && col < SPEKTRUM_SRXL_TEXTGEN_BUFFER_COLS) {
+    if (row < SPEKTRUM_SRXL_TEXTGEN_ROWS && col < SPEKTRUM_SRXL_TEXTGEN_COLS) {
       // Only update and force a tm transmision if something has actually changed.
         if (srxlTextBuff[row][col] != c) {
           srxlTextBuff[row][col] = c;
@@ -508,18 +501,18 @@ bool srxlFrameText(sbuf_t *dst, timeUs_t currentTimeUs)
 
     // Skip already sent lines...
     while (lineSent[lineNo] &&
-           lineCount < SPEKTRUM_SRXL_DEVICE_TEXTGEN_ROWS) {
-        lineNo = (lineNo + 1) % SPEKTRUM_SRXL_DEVICE_TEXTGEN_ROWS;
+           lineCount < SPEKTRUM_SRXL_TEXTGEN_ROWS) {
+        lineNo = (lineNo + 1) % SPEKTRUM_SRXL_TEXTGEN_ROWS;
         lineCount++;
     }
 
     sbufWriteU8(dst, SPEKTRUM_SRXL_DEVICE_TEXTGEN);
     sbufWriteU8(dst, SRXL_FRAMETYPE_SID);
     sbufWriteU8(dst, lineNo);
-    sbufWriteData(dst, srxlTextBuff[lineNo], SPEKTRUM_SRXL_DEVICE_TEXTGEN_COLS);
+    sbufWriteData(dst, srxlTextBuff[lineNo], SPEKTRUM_SRXL_TEXTGEN_COLS);
 
     lineSent[lineNo] = true;
-    lineNo = (lineNo + 1) % SPEKTRUM_SRXL_DEVICE_TEXTGEN_ROWS;
+    lineNo = (lineNo + 1) % SPEKTRUM_SRXL_TEXTGEN_ROWS;
 
     return true;
 }

--- a/src/main/telemetry/srxl.h
+++ b/src/main/telemetry/srxl.h
@@ -27,9 +27,9 @@ void initSrxlTelemetry(void);
 bool checkSrxlTelemetryState(void);
 void handleSrxlTelemetry(timeUs_t currentTimeUs);
 
-#define SPEKTRUM_SRXL_TEXTGEN_BUFFER_ROWS 9
-#define SPEKTRUM_SRXL_TEXTGEN_BUFFER_COLS 12 // Airware 1.20
-//#define SPEKTRUM_SRXL_TEXTGEN_BUFFER_COLS 13 // Airware 1.21
+#define SPEKTRUM_SRXL_TEXTGEN_ROWS 9
+//#define SPEKTRUM_SRXL_TEXTGEN_COLS 12 // Airware 1.20
+#define SPEKTRUM_SRXL_TEXTGEN_COLS 13 // Airware 1.21
 #define SPEKTRUM_SRXL_TEXTGEN_CLEAR_SCREEN 255
 
 int spektrumTmTextGenPutChar(uint8_t col, uint8_t row, char c);


### PR DESCRIPTION
Refactor SRXL telemetry Textgen and CMS displayport.to use one and only one definition of display rows and cols. Clean up old sins.....
Also allow one more char, in total now 13 columns per row. Old 12 char limit was to adapt to some Tx limitation that has been fixed long ago. RF should not work around that, if someone still has this Tx problem they should update their Tx. 
