### PR TITLE
telemetry - pl5 - fix: don't attempt to send requests if telemetry port not configured for half duplex operation

### DIFF
--- a/src/main/sensors/esc_sensor.c
+++ b/src/main/sensors/esc_sensor.c
@@ -1648,8 +1648,8 @@ static bool pl5DecodeTeleFrame(timeUs_t currentTimeUs)
 
     rrfsmFrameTimeout = PL5_TELE_FRAME_TIMEOUT;
 
-    // schedule next request
-    if (paramMspActive)
+    // schedule next request (only if halfduplex)
+    if (paramMspActive && paramCommit != NULL)
         pl5BuildNextReq();
 
     return true;


### PR DESCRIPTION
Fix for FC crash when attempting MSP_ESC_PARAMETERS on HW5 ESC on full-duplex UART / MODE_RX.
MSP request should be ignored in this case as request/response communication is not possible w/o half-duplex / MODE_RXTX port configuration.
This was missed for HW5/PL5, code attempted to send data w/ bad results.