### PR TITLE
Reinstate beep on disarm.

### DIFF
--- a/src/main/fc/core.c
+++ b/src/main/fc/core.c
@@ -441,7 +441,7 @@ void disarm(flightLogDisarmReason_e reason)
             writeEEPROMDelayed(500000);
         }
 
-        if (!(getArmingDisableFlags() )) {
+        if (!getArmingDisableFlags()) {
             beeper(BEEPER_DISARMING);      // emit disarm tone
         }
     }

--- a/src/main/fc/core.c
+++ b/src/main/fc/core.c
@@ -440,6 +440,10 @@ void disarm(flightLogDisarmReason_e reason)
         if (saveRequired) {
             writeEEPROMDelayed(500000);
         }
+
+        if (!(getArmingDisableFlags() )) {
+            beeper(BEEPER_DISARMING);      // emit disarm tone
+        }
     }
 }
 


### PR DESCRIPTION
For some reason, beep on disarm was removed from firmware. But still selectable on RFC beepers tab. Re-instate it in firmware.