### PR TITLE
[SBUS2] Fix units reported in esc sensor and report rotorflight's rpm, instead of escData

### DIFF
--- a/docs/Telemetry.md
+++ b/docs/Telemetry.md
@@ -345,7 +345,7 @@ It runs at a fixed baud rate of 100000 8e2.
 ```
 
 ### Radio Configuration
-The following sensors should setup on your radio
+The following sensors should setup on your radio and Gear ratio for RPM Sensor and Kontronik ESC to 1.00 in your radio.
 | Slot | Sensort Type | Notes |
 | --- | --- | --- |
 | 1 | Voltage | FC Voltage sensor. Pack and cell voltages |

--- a/src/main/telemetry/sbus2.c
+++ b/src/main/telemetry/sbus2.c
@@ -98,7 +98,7 @@ void handleSbus2Telemetry(timeUs_t currentTimeUs)
 
     if (escData != NULL) {
         // 8 slots, esc
-        send_kontronik(8,  escData->voltage * 0.1f, escData->consumption * 100, escData->erpm, escData->current * 0.01f , escData->temperature * 10, escData->temperature2 * 10, escData->bec_current * 10, escData->pwm);
+        send_kontronik(8,  escData->voltage * 0.1f, escData->consumption * 100, escData->erpm, escData->current * 0.01f , escData->temperature * 0.1f, escData->temperature2 * 0.1, escData->bec_current * 10, escData->pwm);
     }
 }
 

--- a/src/main/telemetry/sbus2.c
+++ b/src/main/telemetry/sbus2.c
@@ -98,7 +98,7 @@ void handleSbus2Telemetry(timeUs_t currentTimeUs)
 
     if (escData != NULL) {
         // 8 slots, esc
-        send_kontronik(8,  escData->voltage * 0.1f, escData->consumption * 100, rpm, escData->current * 10, escData->temperature * 0.1f, escData->temperature2 * 0.1f, escData->bec_current * 10, escData->pwm * 0.1f);
+        send_kontronik(8,  escData->voltage * 0.1f, escData->consumption * 100, rpm, escData->current * 0.01f, escData->temperature * 0.1f, escData->temperature2 * 0.1f, escData->bec_current * 10, escData->pwm * 0.1f);
     }
 }
 

--- a/src/main/telemetry/sbus2.c
+++ b/src/main/telemetry/sbus2.c
@@ -98,7 +98,7 @@ void handleSbus2Telemetry(timeUs_t currentTimeUs)
 
     if (escData != NULL) {
         // 8 slots, esc
-        send_kontronik(8,  escData->voltage * 0.1f, escData->consumption * 100, escData->erpm, escData->current * 0.01f , escData->temperature * 0.1f, escData->temperature2 * 0.1, escData->bec_current * 10, escData->pwm);
+        send_kontronik(8,  escData->voltage * 0.1f, escData->consumption * 100, rpm, escData->current * 10, escData->temperature * 0.1f, escData->temperature2 * 0.1f, escData->bec_current * 10, escData->pwm * 0.1f);
     }
 }
 


### PR DESCRIPTION
I could not match  rotorflight's rpm data with headspeed by setting the right gear ratio on the radio.

So it is probably better to set ratio to 1:1 in the radio and report rotorflight's rpm.
