### PR TITLE
Fixed ESC ID (signature) missing from telemetry

### DIFF
--- a/src/main/telemetry/sensors.c
+++ b/src/main/telemetry/sensors.c
@@ -102,7 +102,7 @@ static int getEscSensorValue(uint8_t motor, uint8_t id)
             case 11:
                 return data->status;
             case 12:
-                return 0; // data->model_id
+                return data->id;
         }
     }
 


### PR DESCRIPTION
Fixed / implemented sensor ESC#1 Model Id (Esc#) as escSensorData_t->id (was hardcoded to 0)