### PR TITLE
Add freq_input_edge and freq_input_pull parameters

### DIFF
--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -493,6 +493,14 @@ const char * const lookupTableTelemMode[] = {
     "NATIVE", "CUSTOM",
 };
 
+const char * const lookupTablePullMode[] = {
+    "NOPULL", "PULLUP", "PULLDOWN"
+};
+
+const char * const lookupTableEdgeMode[] = {
+    "FALLING", "RISING"
+};
+
 #define LOOKUP_TABLE_ENTRY(name) { name, ARRAYLEN(name) }
 
 const lookupTableEntry_t lookupTables[] = {
@@ -604,6 +612,8 @@ const lookupTableEntry_t lookupTables[] = {
     LOOKUP_TABLE_ENTRY(lookupTableSwashType),
     LOOKUP_TABLE_ENTRY(lookupTableDtermMode),
     LOOKUP_TABLE_ENTRY(lookupTableTelemMode),
+    LOOKUP_TABLE_ENTRY(lookupTablePullMode),
+    LOOKUP_TABLE_ENTRY(lookupTableEdgeMode),
 };
 
 #undef LOOKUP_TABLE_ENTRY
@@ -741,6 +751,12 @@ const clivalue_t valueTable[] = {
 // PG_PWM_CONFIG
 #if defined(USE_PWM)
     { "input_filtering_mode",       VAR_INT8   | MASTER_VALUE | MODE_LOOKUP,  .config.lookup = { TABLE_OFF_ON }, PG_PWM_CONFIG, offsetof(pwmConfig_t, inputFilteringMode) },
+#endif
+
+// PG_FREQ_SENSOR_CONFIG
+#if defined(USE_FREQ_SENSOR)
+    { "freq_input_pull",            VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP,  .config.lookup = { TABLE_INPUT_PULL_MODE }, PG_FREQ_SENSOR_CONFIG, offsetof(freqConfig_t, pullupdn) },
+    { "freq_input_edge",            VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP,  .config.lookup = { TABLE_INPUT_EDGE_MODE }, PG_FREQ_SENSOR_CONFIG, offsetof(freqConfig_t, polarity) },
 #endif
 
 // PG_BLACKBOX_CONFIG

--- a/src/main/cli/settings.h
+++ b/src/main/cli/settings.h
@@ -130,6 +130,9 @@ typedef enum {
     TABLE_DTERM_MODE,
     TABLE_TELEM_MODE,
 
+    TABLE_INPUT_PULL_MODE,
+    TABLE_INPUT_EDGE_MODE,
+
     LOOKUP_TABLE_COUNT
 } lookupTableIndex_e;
 

--- a/src/main/drivers/freq.c
+++ b/src/main/drivers/freq.c
@@ -339,7 +339,13 @@ void freqInit(const freqConfig_t *freqConfig)
 
             input->pin = IOGetByTag(freqConfig->ioTag[port]);
             IOInit(input->pin, OWNER_FREQ, RESOURCE_INDEX(port));
-            IOConfigGPIOAF(input->pin, IOCFG_AF_PP_UP, timer->alternateFunction);
+
+            const ioConfig_t iocfg =
+                (freqConfig->pullupdn == FREQ_INPUT_PULLUP) ? IOCFG_AF_PP_UP :
+                (freqConfig->pullupdn == FREQ_INPUT_PULLDOWN) ? IOCFG_AF_PP_PD :
+                IOCFG_AF_PP;
+
+            IOConfigGPIOAF(input->pin, iocfg, timer->alternateFunction);
 
             timerConfigure(timer, 0, timerClock(timer->tim));
 
@@ -353,7 +359,7 @@ void freqInit(const freqConfig_t *freqConfig)
                 timerChConfigCallbacks(timer, &input->edgeCb, &input->overflowCb);
             }
 
-            freqICConfig(timer, false, 4);
+            freqICConfig(timer, freqConfig->polarity, 4);
             freqSetBaseClock(input, input->prescaler);
             freqResetCapture(input, port);
         }

--- a/src/main/pg/freq.c
+++ b/src/main/pg/freq.c
@@ -36,6 +36,9 @@ void pgResetFn_freqConfig(freqConfig_t *freqConfig)
     for (unsigned index = 0; index < FREQ_SENSOR_PORT_COUNT; index++) {
         freqConfig->ioTag[index] = timerioTagGetByUsage(TIM_USE_FREQ, index);
     }
+
+    freqConfig->pullupdn = FREQ_INPUT_PULLUP;
+    freqConfig->polarity = FREQ_INPUT_FALLING_EDGE;
 }
 
 #endif

--- a/src/main/pg/freq.h
+++ b/src/main/pg/freq.h
@@ -22,8 +22,21 @@
 
 #include "pg/pg.h"
 
+enum {
+    FREQ_INPUT_NOPULL,
+    FREQ_INPUT_PULLUP,
+    FREQ_INPUT_PULLDOWN,
+};
+
+enum {
+    FREQ_INPUT_FALLING_EDGE,
+    FREQ_INPUT_RISING_EDGE,
+};
+
 typedef struct freqConfig_s {
     ioTag_t ioTag[FREQ_SENSOR_PORT_COUNT];
+    uint8_t pullupdn;
+    uint8_t polarity;
 } freqConfig_t;
 
 PG_DECLARE(freqConfig_t, freqConfig);


### PR DESCRIPTION
This adds two configuration parameters to the freq input (RPM sensor).
```
freq_input_edge = < RAISING | FALLING >
freq_input_pull = < NOPULL | PULLUP | PULLDOWN >
```
The `edge` setting changes whether the frequency is detected from the falling/raising signal edge.
The pull up/down/none selects the internal pullup/pulldown resistors.

Most external electric sensors are FALLING + PULLUP, and this was fixed earlier.
Most hall sensors are likely this too.

With ESC integrated RPM signal, FALLING + PULLUP is also fine.

Task is now to check if there are sensors that are not.