### PR TITLE
Allow for longer FC_VERSION_STRING

### DIFF
--- a/src/main/osd/osd.c
+++ b/src/main/osd/osd.c
@@ -433,7 +433,7 @@ static void osdCompleteInitialization(void)
 
     osdDrawLogo(3, 1);
 
-    char string_buffer[30];
+    char string_buffer[sizeof FC_VERSION_STRING + 2];
     tfp_sprintf(string_buffer, "V%s", FC_VERSION_STRING);
     displayWrite(osdDisplayPort, 20, 6, DISPLAYPORT_ATTR_NONE, string_buffer);
 #ifdef USE_CMS

--- a/src/main/telemetry/crsf.c
+++ b/src/main/telemetry/crsf.c
@@ -517,9 +517,14 @@ void crsfFrameFlightMode(sbuf_t *dst)
  */
 static void crsfFrameDeviceInfo(sbuf_t *dst)
 {
-    char buff[30];
+    char buff[
+        sizeof FC_FIRMWARE_IDENTIFIER +
+        sizeof FC_VERSION_STRING +
+        sizeof systemConfig()->boardIdentifier +
+        4 // allow for separators and NULL
+    ];
 
-    tfp_sprintf(buff, "%s %s: %s", FC_FIRMWARE_NAME, FC_VERSION_STRING, systemConfig()->boardIdentifier);
+    tfp_sprintf(buff, "%s %s: %s", FC_FIRMWARE_IDENTIFIER, FC_VERSION_STRING, systemConfig()->boardIdentifier);
 
     sbufWriteU8(dst, CRSF_FRAMETYPE_DEVICE_INFO);
     sbufWriteU8(dst, CRSF_ADDRESS_RADIO_TRANSMITTER);


### PR DESCRIPTION
Make sure buffer is large enough and changed to FC_FIRMWARE_IDENTIFIER, looks slightly better on small screens:
![20240925_062349](https://github.com/user-attachments/assets/b994911b-c577-4363-bce2-4880a608ccdb)
