### PR TITLE
Add gov_min_throttle

### DIFF
--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -1182,6 +1182,7 @@ const clivalue_t valueTable[] = {
     { "gov_cyclic_ff_weight",       VAR_UINT8  |  PROFILE_VALUE,  .config.minmaxUnsigned = { 0, 250 }, PG_PID_PROFILE, offsetof(pidProfile_t, governor.cyclic_ff_weight) },
     { "gov_collective_ff_weight",   VAR_UINT8  |  PROFILE_VALUE,  .config.minmaxUnsigned = { 0, 250 }, PG_PID_PROFILE, offsetof(pidProfile_t, governor.collective_ff_weight) },
     { "gov_max_throttle",           VAR_UINT8  |  PROFILE_VALUE,  .config.minmaxUnsigned = { 0, 100 }, PG_PID_PROFILE, offsetof(pidProfile_t, governor.max_throttle) },
+    { "gov_min_throttle",           VAR_UINT8  |  PROFILE_VALUE,  .config.minmaxUnsigned = { 0, 100 }, PG_PID_PROFILE, offsetof(pidProfile_t, governor.min_throttle) },
 
 // PG_TELEMETRY_CONFIG
 #ifdef USE_TELEMETRY

--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -1859,6 +1859,7 @@ static bool mspProcessOutCommand(int16_t cmdMSP, sbuf_t *dst)
         sbufWriteU8(dst, currentPidProfile->governor.cyclic_ff_weight);
         sbufWriteU8(dst, currentPidProfile->governor.collective_ff_weight);
         sbufWriteU8(dst, currentPidProfile->governor.max_throttle);
+        sbufWriteU8(dst, currentPidProfile->governor.min_throttle);
         break;
 
     case MSP_SENSOR_CONFIG:
@@ -2617,6 +2618,9 @@ static mspResult_e mspProcessInCommand(mspDescriptor_t srcDesc, int16_t cmdMSP, 
         currentPidProfile->governor.cyclic_ff_weight = sbufReadU8(src);
         currentPidProfile->governor.collective_ff_weight = sbufReadU8(src);
         currentPidProfile->governor.max_throttle = sbufReadU8(src);
+        if (sbufBytesRemaining(src) >= 1) {
+            currentPidProfile->governor.min_throttle = sbufReadU8(src);
+        }
         /* Load new values */
         governorInitProfile(currentPidProfile);
         break;

--- a/src/main/pg/pid.c
+++ b/src/main/pg/pid.c
@@ -125,6 +125,7 @@ void resetPidProfile(pidProfile_t *pidProfile)
         .governor.cyclic_ff_weight = 10,
         .governor.collective_ff_weight = 100,
         .governor.max_throttle = 100,
+        .governor.min_throttle = 10,
     );
 }
 

--- a/src/main/pg/pid.h
+++ b/src/main/pg/pid.h
@@ -89,6 +89,7 @@ typedef struct {
     uint8_t     cyclic_ff_weight;
     uint8_t     collective_ff_weight;
     uint8_t     max_throttle;
+    uint8_t     min_throttle;
 } governorProfile_t;
 
 typedef struct {


### PR DESCRIPTION
Add a new governor parameter `gov_min_throttle` which is applied when the PID control is active.
It's limiting the output throttle to the given value.