### PR TITLE
Add MSP_EXPERIMENTAL and MSP_SET_EXPERIMENTAL

### DIFF
--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -1005,6 +1005,15 @@ static bool mspCommonProcessOutCommand(int16_t cmdMSP, sbuf_t *dst, mspPostProce
         break;
     }
 
+    case MSP_EXPERIMENTAL:
+        /* 
+         * Send your experimental parameters to LUA. Like:
+         *
+         * sbufWriteU8(dst, currentPidProfile->yourFancyParameterA);
+         * sbufWriteU8(dst, currentPidProfile->yourFancyParameterB);
+        */
+        break;
+
     default:
         return false;
     }
@@ -3522,6 +3531,17 @@ static mspResult_e mspCommonProcessInCommand(mspDescriptor_t srcDesc, int16_t cm
         }
         break;
 #endif // OSD
+
+    case MSP_SET_EXPERIMENTAL:
+        /*
+         * Receive your experimental parameters from LUA. Like:
+         *
+         * if (sbufBytesRemaining(src) >= 2) {
+         *     currentPidProfile->yourFancyParameterA = sbufReadU8(src);
+         *     currentPidProfile->yourFancyParameterB = sbufReadU8(src);
+         * }
+        */
+        break;
 
     default:
         return mspProcessInCommand(srcDesc, cmdMSP, src);

--- a/src/main/msp/msp_protocol.h
+++ b/src/main/msp/msp_protocol.h
@@ -194,6 +194,9 @@
 #define MSP_LED_STRIP_SETTINGS               150
 #define MSP_SET_LED_STRIP_SETTINGS           151
 
+#define MSP_EXPERIMENTAL                     158
+#define MSP_SET_EXPERIMENTAL                 159
+
 #define MSP_UID                              160
 
 #define MSP_GPSSVINFO                        164


### PR DESCRIPTION
Add a placeholder for adjusting experimental parameters from LUA. This allows devs to quickly expose parameters to LUA for field tuning, without create their own LUA.