### PR TITLE
Rf sbus out msp

### DIFF
--- a/src/main/drivers/sbus_output.c
+++ b/src/main/drivers/sbus_output.c
@@ -168,7 +168,6 @@ void sbusOutInit()
     sbusOutPort = openSerialPort(
         portConfig->identifier, FUNCTION_SBUS_OUT, NULL, NULL, 100000, MODE_TX,
         SERIAL_STOPBITS_2 | SERIAL_PARITY_EVEN | SERIAL_INVERTED |
-                SERIAL_UNIDIR | sbusOutConfig()->pinSwap
-            ? SERIAL_PINSWAP
-            : SERIAL_NOSWAP);
+            SERIAL_UNIDIR |
+            (sbusOutConfig()->pinSwap ? SERIAL_PINSWAP : SERIAL_NOSWAP));
 }

--- a/src/main/msp/msp_protocol.h
+++ b/src/main/msp/msp_protocol.h
@@ -193,6 +193,8 @@
 #define MSP_SET_GOVERNOR_PROFILE             149
 #define MSP_LED_STRIP_SETTINGS               150
 #define MSP_SET_LED_STRIP_SETTINGS           151
+#define MSP_SBUS_OUTPUT_CONFIG               152
+#define MSP_SET_SBUS_OUTPUT_CONFIG           153
 
 #define MSP_EXPERIMENTAL                     158
 #define MSP_SET_EXPERIMENTAL                 159

--- a/src/test/unit/sbus_output_unittest.cc
+++ b/src/test/unit/sbus_output_unittest.cc
@@ -125,6 +125,11 @@ TEST(SBusOutInit, ConfigReset) {
     EXPECT_EQ(sbusOutConfig()->frameRate, 50);
 }
 
+MATCHER(IsValidSbusPortOption, "") {
+    return (arg & SERIAL_STOPBITS_2) && (arg & SERIAL_PARITY_EVEN) &&
+           (arg & SERIAL_INVERTED);
+}
+
 TEST(SBusOutInit, GoodPath) {
     StrictMock<MockInterface> mock;
     g_mock = &mock;
@@ -134,7 +139,8 @@ TEST(SBusOutInit, GoodPath) {
     fake_port_config.identifier = fake_identifier;
     serialPort_t fake_port = {};
     EXPECT_CALL(mock, findSerialPortConfig).WillOnce(Return(&fake_port_config));
-    EXPECT_CALL(mock, openSerialPort(fake_identifier, _, _, _, _, _, _))
+    EXPECT_CALL(mock, openSerialPort(fake_identifier, FUNCTION_SBUS_OUT, _, _,
+                                     100000, _, IsValidSbusPortOption()))
         .WillOnce(Return(&fake_port));
 
     sbusOutInit();


### PR DESCRIPTION
Read:
```
    case MSP_SBUS_OUTPUT_CONFIG:
        for (int i = 0; i < SBUS_OUT_CHANNELS; i++) {
            sbufWriteU8(dst, sbusOutConfigMutable()->sourceType[i]);
            sbufWriteU8(dst, sbusOutConfigMutable()->sourceIndex[i]);
            sbufWriteS16(dst, sbusOutConfigMutable()->sourceRangeLow[i]);
            sbufWriteS16(dst, sbusOutConfigMutable()->sourceRangeHigh[i]);
        }
        sbufWriteU8(dst, sbusOutConfigMutable()->frameRate);
        break;
```
Write:
```
    case MSP_SET_SBUS_OUTPUT_CONFIG: {
        // Write format is customized for the size and responsiveness.
        // The first byte will be the target output channel index (0-based).
        // The following bytes will be the type/index/low/high for that channel.
        // `frameRate` is piggyback to any (all) indices for simplicity.
        if (sbufBytesRemaining(src) >= 1) {
            uint8_t index = sbufReadU8(src);
            if (index < SBUS_OUT_CHANNELS && sbufBytesRemaining(src) >= 7) {
                sbusOutConfigMutable()->sourceType[index] = sbufReadU8(src);
                sbusOutConfigMutable()->sourceIndex[index] = sbufReadU8(src);
                sbusOutConfigMutable()->sourceRangeLow[index] = sbufReadS16(src);
                sbusOutConfigMutable()->sourceRangeHigh[index] = sbufReadS16(src);

                // You need to reset FC after updating ->frameRate.
                sbusOutConfigMutable()->frameRate = sbufReadU8(src);
            }
        }
        break;
    }
```