### PR TITLE
Jeti sensors - RF2.1.X

### DIFF
--- a/src/main/telemetry/jetiexbus.c
+++ b/src/main/telemetry/jetiexbus.c
@@ -140,10 +140,11 @@ const exBusSensor_t jetiExSensors[] = {
     {"G-Force Z",       "",         EX_TYPE_22b,   DECIMAL_MASK(3)},
     {"Headspeed",       "rpm",         EX_TYPE_22b,   DECIMAL_MASK(0)},
     {"Tailspeed",       "rpm",         EX_TYPE_22b,   DECIMAL_MASK(0)},
-    {"Arming Flags",       "",         EX_TYPE_22b,   DECIMAL_MASK(0)},
-    {"PID Profile",       "",         EX_TYPE_22b,   DECIMAL_MASK(0)},
-    {"RATES Profile",       "",         EX_TYPE_22b,   DECIMAL_MASK(0)},
-    {"Governor Mode",       "",         EX_TYPE_22b,   DECIMAL_MASK(0)},
+    {"Arming Flags",    "",         EX_TYPE_22b,   DECIMAL_MASK(0)},
+    {"PID Profile",     "",         EX_TYPE_22b,   DECIMAL_MASK(0)},
+    {"RATES Profile",   "",         EX_TYPE_22b,   DECIMAL_MASK(0)},
+    {"Governor",        "",         EX_TYPE_22b,   DECIMAL_MASK(0)},
+    {"Thr. Control",    "",         EX_TYPE_22b,   DECIMAL_MASK(0)},    
 };
 
 // after every 15 sensors increment the step by 2 (e.g. ...EX_VAL15, EX_VAL16 = 17) to skip the device description
@@ -174,6 +175,7 @@ enum exSensors_e {
     EX_PID_PROFILE,
     EX_RATES_PROFILE,
     EX_GOVERNOR_MODE,
+    EX_THROTTLE_CONTROL
 };
 
 union{
@@ -286,7 +288,7 @@ void initJetiExBusTelemetry(void)
     bitArraySet(&exSensorEnabled, EX_PID_PROFILE);
     bitArraySet(&exSensorEnabled, EX_RATES_PROFILE);
     bitArraySet(&exSensorEnabled, EX_GOVERNOR_MODE);
-   
+    bitArraySet(&exSensorEnabled, EX_THROTTLE_CONTROL);   
 
     firstActiveSensor = getNextActiveSensor(0);     // find the first active sensor
 }
@@ -452,6 +454,11 @@ int32_t getSensorValue(uint8_t sensor)
                     */
                     return getGovernorState();
                 }    
+
+    case EX_THROTTLE_CONTROL:
+        return telemetrySensorValue(TELEM_THROTTLE_CONTROL);
+    break;
+
 
     break;
 

--- a/src/main/telemetry/jetiexbus.c
+++ b/src/main/telemetry/jetiexbus.c
@@ -38,7 +38,7 @@
 #include "drivers/serial_uart.h"
 #include "drivers/time.h"
 
-
+#include "flight/governor.h"
 #include "flight/position.h"
 #include "flight/imu.h"
 
@@ -116,7 +116,7 @@ typedef struct exBusSensor_s {
 // list of telemetry messages
 // after every 15 sensors a new header has to be inserted (e.g. "BF D2")
 const exBusSensor_t jetiExSensors[] = {
-    {"BF D1",           "",         EX_TYPE_DES,   0              },     // device descripton
+    {"Rotorflight D1",           "",         EX_TYPE_DES,   0              },     // device descripton
     {"Voltage",         "V",        EX_TYPE_22b,   DECIMAL_MASK(1)},
     {"Current",         "A",        EX_TYPE_22b,   DECIMAL_MASK(2)},
     {"Altitude",        "m",        EX_TYPE_22b,   DECIMAL_MASK(2)},
@@ -132,12 +132,18 @@ const exBusSensor_t jetiExSensors[] = {
     {"GPS Speed",       "m/s",      EX_TYPE_22b,   DECIMAL_MASK(2)},
     {"GPS H-Distance",  "m",        EX_TYPE_22b,   DECIMAL_MASK(0)},
     {"GPS H-Direction", "\xB0",     EX_TYPE_22b,   DECIMAL_MASK(1)},
-    {"BF D2",           "",         EX_TYPE_DES,   0              },     // device descripton
+    {"Rotorflight D2",           "",         EX_TYPE_DES,   0              },     // device descripton
     {"GPS Heading",     "\xB0",     EX_TYPE_22b,   DECIMAL_MASK(1)},
     {"GPS Altitude",    "m",        EX_TYPE_22b,   DECIMAL_MASK(2)},
     {"G-Force X",       "",         EX_TYPE_22b,   DECIMAL_MASK(3)},
     {"G-Force Y",       "",         EX_TYPE_22b,   DECIMAL_MASK(3)},
-    {"G-Force Z",       "",         EX_TYPE_22b,   DECIMAL_MASK(3)}
+    {"G-Force Z",       "",         EX_TYPE_22b,   DECIMAL_MASK(3)},
+    {"Headspeed",       "rpm",         EX_TYPE_22b,   DECIMAL_MASK(0)},
+    {"Tailspeed",       "rpm",         EX_TYPE_22b,   DECIMAL_MASK(0)},
+    {"Arming Flags",       "",         EX_TYPE_22b,   DECIMAL_MASK(0)},
+    {"PID Profile",       "",         EX_TYPE_22b,   DECIMAL_MASK(0)},
+    {"RATES Profile",       "",         EX_TYPE_22b,   DECIMAL_MASK(0)},
+    {"Governor Mode",       "",         EX_TYPE_22b,   DECIMAL_MASK(0)},
 };
 
 // after every 15 sensors increment the step by 2 (e.g. ...EX_VAL15, EX_VAL16 = 17) to skip the device description
@@ -161,7 +167,13 @@ enum exSensors_e {
     EX_GPS_ALTITUDE,
     EX_GFORCE_X,
     EX_GFORCE_Y,
-    EX_GFORCE_Z
+    EX_GFORCE_Z,
+    EX_HEADSPEED,
+    EX_TAILSPEED,
+    EX_ARMING_FLAGS,
+    EX_PID_PROFILE,
+    EX_RATES_PROFILE,
+    EX_GOVERNOR_MODE,
 };
 
 union{
@@ -266,6 +278,15 @@ void initJetiExBusTelemetry(void)
     }
 
     enableGpsTelemetry(featureIsEnabled(FEATURE_GPS));
+
+
+    bitArraySet(&exSensorEnabled, EX_HEADSPEED);
+    bitArraySet(&exSensorEnabled, EX_TAILSPEED);
+    bitArraySet(&exSensorEnabled, EX_ARMING_FLAGS);
+    bitArraySet(&exSensorEnabled, EX_PID_PROFILE);
+    bitArraySet(&exSensorEnabled, EX_RATES_PROFILE);
+    bitArraySet(&exSensorEnabled, EX_GOVERNOR_MODE);
+   
 
     firstActiveSensor = getNextActiveSensor(0);     // find the first active sensor
 }
@@ -390,6 +411,50 @@ int32_t getSensorValue(uint8_t sensor)
         return (int16_t)(((float)acc.accADC[2] / acc.dev.acc_1G) * 1000);
     break;
 #endif
+
+    case EX_HEADSPEED:
+        return telemetrySensorValue(TELEM_HEADSPEED);
+    break;
+
+    case EX_TAILSPEED:
+        return telemetrySensorValue(TELEM_TAILSPEED);
+    break;
+
+    case EX_ARMING_FLAGS:
+        return telemetrySensorValue(TELEM_ARMING_FLAGS);
+    break;
+
+    case EX_PID_PROFILE:
+        return telemetrySensorValue(TELEM_PID_PROFILE);
+    break;
+
+    case EX_RATES_PROFILE:
+        return telemetrySensorValue(TELEM_RATES_PROFILE);
+    break;
+
+    case EX_GOVERNOR_MODE:
+                if (!ARMING_FLAG(ARMED)) {
+                    if (isArmingDisabled())
+                        return 100;  //DISABLED
+                    else
+                       return 101; //DISAMED
+                } else {
+                    /*
+                        0, //"OFF",
+                        1, //"IDLE",
+                        2, // "SPOOLUP",
+                        3, //"RECOVERY",
+                        4, //"ACTIVE",
+                        5, //"THR-OFF",
+                        6, //"LOST-HS",
+                        7, //"AUTOROT",
+                        8, //"BAILOUT",
+                    */
+                    return getGovernorState();
+                }    
+
+    break;
+
 
     default:
         return -1;

--- a/src/main/telemetry/jetiexbus.c
+++ b/src/main/telemetry/jetiexbus.c
@@ -155,8 +155,6 @@ const exBusSensor_t jetiExSensors[] = {
     {"Adj. Function",    "",        EX_TYPE_22b,   DECIMAL_MASK(0)},
     {"Adj. Value",       "",        EX_TYPE_22b,   DECIMAL_MASK(0)},
     {"ESC. Temp.",       "\xB0",    EX_TYPE_22b,   DECIMAL_MASK(1)},
-    {"Rotorflight D3",           "",         EX_TYPE_DES,   0              },     // device descripton    
-    {"MCU. Temp.",       "\xB0",    EX_TYPE_22b,   DECIMAL_MASK(1)},    
 };
 
 // after every 15 sensors increment the step by 2 (e.g. ...EX_VAL15, EX_VAL16 = 17) to skip the device description
@@ -192,8 +190,6 @@ enum exSensors_e {
     EX_ADJFUNC,
     EX_ADJVALUE,
     EX_ESCTEMP,
-    //D3
-    EX_MCUTEMP = 33,
 };
 
 union{
@@ -309,14 +305,11 @@ void initJetiExBusTelemetry(void)
     bitArraySet(&exSensorEnabled, EX_THROTTLE_CONTROL);
     bitArraySet(&exSensorEnabled, EX_ADJFUNC);
     bitArraySet(&exSensorEnabled, EX_ADJVALUE);
+
     
 #ifdef USE_ESC_SENSOR_TELEMETRY    
     bitArraySet(&exSensorEnabled, EX_ESCTEMP);
 #endif
-
-#if defined(USE_ADC_INTERNAL)
-    bitArraySet(&exSensorEnabled, EX_MCUTEMP);
-#endif    
 
     firstActiveSensor = getNextActiveSensor(0);     // find the first active sensor
 }
@@ -507,11 +500,6 @@ int32_t getSensorValue(uint8_t sensor)
     break;
 #endif
 
-#if defined(USE_ADC_INTERNAL)
-    case EX_MCUTEMP:
-            return getCoreTemperatureCelsius();
-    break;
-#endif
 
     default:
         return -1;


### PR DESCRIPTION
Added in additional sensors to work with jeti.

Currently added:

headspeed
tailspeed
arming flags
pid profile
rate profile
governor mode
throttle control
adjfunction
adjvalue
esc temp
From tests it seems that this is now the max number of sensors we can add. Next steps would be a total refactor of telem to make sensors selectable. I dont have time to do that - so this will have to suffice.