### PR TITLE
Introduce collective scaling

### DIFF
--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -921,8 +921,8 @@ const clivalue_t valueTable[] = {
     { "swash_pitch_limit",          VAR_UINT16 | MASTER_VALUE,  .config.minmaxUnsigned = { 0, 3000 }, PG_GENERIC_MIXER_CONFIG, offsetof(mixerConfig_t, swash_pitch_limit) },
     { "swash_tta_precomp",          VAR_UINT8  | MASTER_VALUE,  .config.minmaxUnsigned = { 0, 250 }, PG_GENERIC_MIXER_CONFIG, offsetof(mixerConfig_t, swash_tta_precomp) },
     { "swash_geo_correction",       VAR_INT8   | MASTER_VALUE,  .config.minmax = { -125, 125 }, PG_GENERIC_MIXER_CONFIG, offsetof(mixerConfig_t, swash_geo_correction) },
-    { "collective_scale_pos",       VAR_INT8   | MASTER_VALUE,  .config.minmax = { -100, 100 }, PG_GENERIC_MIXER_CONFIG, offsetof(mixerConfig_t, collective_scale_pos) },
-    { "collective_scale_neg",       VAR_INT8   | MASTER_VALUE,  .config.minmax = { -100, 100 }, PG_GENERIC_MIXER_CONFIG, offsetof(mixerConfig_t, collective_scale_neg) },
+    { "collective_geo_correction_pos", VAR_INT8 | MASTER_VALUE,  .config.minmax = { -100, 100 }, PG_GENERIC_MIXER_CONFIG, offsetof(mixerConfig_t, collective_geo_correction_pos) },
+    { "collective_geo_correction_neg", VAR_INT8 | MASTER_VALUE,  .config.minmax = { -100, 100 }, PG_GENERIC_MIXER_CONFIG, offsetof(mixerConfig_t, collective_geo_correction_neg) },
 
 // PG_GOVERNOR_CONFIG
     { "gov_mode",                   VAR_UINT8  |  MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_GOVERNOR_MODE }, PG_GOVERNOR_CONFIG, offsetof(governorConfig_t, gov_mode) },

--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -921,6 +921,8 @@ const clivalue_t valueTable[] = {
     { "swash_pitch_limit",          VAR_UINT16 | MASTER_VALUE,  .config.minmaxUnsigned = { 0, 3000 }, PG_GENERIC_MIXER_CONFIG, offsetof(mixerConfig_t, swash_pitch_limit) },
     { "swash_tta_precomp",          VAR_UINT8  | MASTER_VALUE,  .config.minmaxUnsigned = { 0, 250 }, PG_GENERIC_MIXER_CONFIG, offsetof(mixerConfig_t, swash_tta_precomp) },
     { "swash_geo_correction",       VAR_INT8   | MASTER_VALUE,  .config.minmax = { -125, 125 }, PG_GENERIC_MIXER_CONFIG, offsetof(mixerConfig_t, swash_geo_correction) },
+    { "collective_scale_pos",       VAR_INT8   | MASTER_VALUE,  .config.minmax = { -100, 100 }, PG_GENERIC_MIXER_CONFIG, offsetof(mixerConfig_t, collective_scale_pos) },
+    { "collective_scale_neg",       VAR_INT8   | MASTER_VALUE,  .config.minmax = { -100, 100 }, PG_GENERIC_MIXER_CONFIG, offsetof(mixerConfig_t, collective_scale_neg) },
 
 // PG_GOVERNOR_CONFIG
     { "gov_mode",                   VAR_UINT8  |  MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_GOVERNOR_MODE }, PG_GOVERNOR_CONFIG, offsetof(governorConfig_t, gov_mode) },

--- a/src/main/flight/mixer.c
+++ b/src/main/flight/mixer.c
@@ -346,6 +346,19 @@ static float mixerCollectiveCorrection(float SC)
     return SC;
 }
 
+static float mixerCollectiveScale(float SC, float SR, float SP)
+{
+    float beta;
+    if (SC > 0) {
+        beta = mixerConfig()->collective_scale_pos / 100.0f;
+    } else {
+        beta = -mixerConfig()->collective_scale_neg / 100.0f;
+    }
+    float scale = 1 + beta * (SR * SR + SP * SP);
+    scale = constrainf(scale, 0.0f, 2.0f);
+    return SC * scale;
+}
+
 static void mixerUpdateMotorizedTail(void)
 {
     // Motorized tail control
@@ -415,6 +428,7 @@ static void mixerUpdateSwash(void)
         float TC = mixer.tailCenterTrim;
 
         SC = mixerCollectiveCorrection(SC);
+        SC = mixerCollectiveScale(SC, SR, SP);
 
         SR += mixer.swashTrim[0];
         SP += mixer.swashTrim[1];

--- a/src/main/flight/mixer.c
+++ b/src/main/flight/mixer.c
@@ -350,9 +350,9 @@ static float mixerCollectiveScale(float SC, float SR, float SP)
 {
     float beta;
     if (SC > 0) {
-        beta = mixerConfig()->collective_scale_pos / 100.0f;
+        beta = mixerConfig()->collective_geo_correction_pos / 100.0f;
     } else {
-        beta = -mixerConfig()->collective_scale_neg / 100.0f;
+        beta = -mixerConfig()->collective_geo_correction_neg / 100.0f;
     }
     float scale = 1 + beta * (SR * SR + SP * SP);
     scale = constrainf(scale, 0.0f, 2.0f);

--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -1518,6 +1518,8 @@ static bool mspProcessOutCommand(int16_t cmdMSP, sbuf_t *dst)
         sbufWriteU16(dst, mixerConfig()->swash_trim[2]);
         sbufWriteU8(dst, mixerConfig()->swash_tta_precomp);
         sbufWriteU8(dst, mixerConfig()->swash_geo_correction);
+        sbufWriteS8(dst, mixerConfig()->collective_scale_pos);
+        sbufWriteS8(dst, mixerConfig()->collective_scale_neg);
         break;
 
     case MSP_MIXER_INPUTS:
@@ -3043,6 +3045,10 @@ static mspResult_e mspProcessInCommand(mspDescriptor_t srcDesc, int16_t cmdMSP, 
         mixerConfigMutable()->swash_trim[2] = sbufReadU16(src);
         mixerConfigMutable()->swash_tta_precomp = sbufReadU8(src);
         mixerConfigMutable()->swash_geo_correction = sbufReadU8(src);
+        if (sbufBytesRemaining(src) >= 2) {
+            mixerConfigMutable()->collective_scale_pos = sbufReadS8(src);
+            mixerConfigMutable()->collective_scale_neg = sbufReadS8(src);
+        }
         mixerInitConfig();
         break;
 

--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -1007,7 +1007,7 @@ static bool mspCommonProcessOutCommand(int16_t cmdMSP, sbuf_t *dst, mspPostProce
     }
 
     case MSP_EXPERIMENTAL:
-        /* 
+        /*
          * Send your experimental parameters to LUA. Like:
          *
          * sbufWriteU8(dst, currentPidProfile->yourFancyParameterA);
@@ -1518,8 +1518,8 @@ static bool mspProcessOutCommand(int16_t cmdMSP, sbuf_t *dst)
         sbufWriteU16(dst, mixerConfig()->swash_trim[2]);
         sbufWriteU8(dst, mixerConfig()->swash_tta_precomp);
         sbufWriteU8(dst, mixerConfig()->swash_geo_correction);
-        sbufWriteS8(dst, mixerConfig()->collective_scale_pos);
-        sbufWriteS8(dst, mixerConfig()->collective_scale_neg);
+        sbufWriteS8(dst, mixerConfig()->collective_geo_correction_pos);
+        sbufWriteS8(dst, mixerConfig()->collective_geo_correction_neg);
         break;
 
     case MSP_MIXER_INPUTS:
@@ -3046,8 +3046,8 @@ static mspResult_e mspProcessInCommand(mspDescriptor_t srcDesc, int16_t cmdMSP, 
         mixerConfigMutable()->swash_tta_precomp = sbufReadU8(src);
         mixerConfigMutable()->swash_geo_correction = sbufReadU8(src);
         if (sbufBytesRemaining(src) >= 2) {
-            mixerConfigMutable()->collective_scale_pos = sbufReadS8(src);
-            mixerConfigMutable()->collective_scale_neg = sbufReadS8(src);
+            mixerConfigMutable()->collective_geo_correction_pos = sbufReadS8(src);
+            mixerConfigMutable()->collective_geo_correction_neg = sbufReadS8(src);
         }
         mixerInitConfig();
         break;

--- a/src/main/pg/mixer.c
+++ b/src/main/pg/mixer.c
@@ -38,6 +38,8 @@ PG_RESET_TEMPLATE(mixerConfig_t, mixerConfig,
     .swash_trim = { 0, 0, 0 },
     .swash_tta_precomp = 0,
     .swash_geo_correction = 0,
+    .collective_scale_pos = 0,
+    .collective_scale_neg = 10,
 );
 
 PG_REGISTER_ARRAY(mixerRule_t, MIXER_RULE_COUNT, mixerRules, PG_GENERIC_MIXER_RULES, 0);

--- a/src/main/pg/mixer.c
+++ b/src/main/pg/mixer.c
@@ -38,8 +38,8 @@ PG_RESET_TEMPLATE(mixerConfig_t, mixerConfig,
     .swash_trim = { 0, 0, 0 },
     .swash_tta_precomp = 0,
     .swash_geo_correction = 0,
-    .collective_scale_pos = 0,
-    .collective_scale_neg = 10,
+    .collective_geo_correction_pos = 0,
+    .collective_geo_correction_neg = 10,
 );
 
 PG_REGISTER_ARRAY(mixerRule_t, MIXER_RULE_COUNT, mixerRules, PG_GENERIC_MIXER_RULES, 0);

--- a/src/main/pg/mixer.h
+++ b/src/main/pg/mixer.h
@@ -107,6 +107,8 @@ typedef struct
 
     int8_t    swash_geo_correction; // Head geometry correction (collective assymetry)
 
+    int8_t    collective_scale_pos;
+    int8_t    collective_scale_neg;
 } mixerConfig_t;
 
 PG_DECLARE(mixerConfig_t, mixerConfig);

--- a/src/main/pg/mixer.h
+++ b/src/main/pg/mixer.h
@@ -107,8 +107,8 @@ typedef struct
 
     int8_t    swash_geo_correction; // Head geometry correction (collective assymetry)
 
-    int8_t    collective_scale_pos;
-    int8_t    collective_scale_neg;
+    int8_t    collective_geo_correction_pos;
+    int8_t    collective_geo_correction_neg;
 } mixerConfig_t;
 
 PG_DECLARE(mixerConfig_t, mixerConfig);


### PR DESCRIPTION
Introduce 2 new params `collective_scale_pos` and `collective_scale_neg`.
These 2 params set cyclic -> collective mixing to compensate linkage tilting:
```
SC *= (1 + beta* (SR*SR + SP*SP))
```

To compensate the fish eye ball dropping when cyclic is full, set
positive value to either side (_pos or _neg). To compensate the raising,
set negative value.

`collective_scale_pos` has a default 0 and `collective_scale_neg` has 10 as etocii suggested

MSP MSP_MIXER_CONFIG protocol is updated and corresponding changes needs to be done in the lua and configurator.