### PR TITLE
Flashfs rolling erase

### DIFF
--- a/src/main/blackbox/blackbox.c
+++ b/src/main/blackbox/blackbox.c
@@ -335,6 +335,8 @@ static const blackboxSimpleFieldDefinition_t blackboxSlowFields[] = {
 typedef enum BlackboxState {
     BLACKBOX_STATE_DISABLED = 0,
     BLACKBOX_STATE_STOPPED,
+    BLACKBOX_STATE_WAIT_FOR_READY,
+    BLACKBOX_STATE_INITIAL_ERASE,
     BLACKBOX_STATE_PREPARE_LOG_FILE,
     BLACKBOX_STATE_SEND_HEADER,
     BLACKBOX_STATE_SEND_MAIN_FIELD_HEADER,
@@ -345,6 +347,7 @@ typedef enum BlackboxState {
     BLACKBOX_STATE_CACHE_FLUSH,
     BLACKBOX_STATE_PAUSED,
     BLACKBOX_STATE_RUNNING,
+    BLACKBOX_STATE_FULL,
     BLACKBOX_STATE_SHUTTING_DOWN,
     BLACKBOX_STATE_START_ERASE,
     BLACKBOX_STATE_ERASING,
@@ -1175,7 +1178,7 @@ static void blackboxStart(void)
     blackboxLastRescueState = getRescueState();
     blackboxLastAirborneState = isAirborne();
 
-    blackboxSetState(BLACKBOX_STATE_PREPARE_LOG_FILE);
+    blackboxSetState(BLACKBOX_STATE_WAIT_FOR_READY);
 }
 
 void blackboxCheckEnabler(void)
@@ -1959,6 +1962,15 @@ bool isBlackboxErased(void)
     return isBlackboxDeviceReady();
 }
 
+void blackboxInitialErase(void)
+{
+#ifdef USE_FLASHFS
+    if (blackboxConfig()->device == BLACKBOX_DEVICE_FLASH) {
+        blackboxDeviceInitialErase();
+    }
+#endif
+}
+
 /**
  * Call each flight loop iteration to perform blackbox logging.
  */
@@ -1978,6 +1990,17 @@ void blackboxUpdate(timeUs_t currentTimeUs)
         if (blackboxIsLoggingEnabled()) {
             blackboxOpen();
             blackboxStart();
+        }
+        break;
+    case BLACKBOX_STATE_WAIT_FOR_READY:
+        if (isBlackboxDeviceReady()) {
+            blackboxInitialErase();
+            blackboxSetState(BLACKBOX_STATE_INITIAL_ERASE);
+        }
+        break;
+    case BLACKBOX_STATE_INITIAL_ERASE:
+        if (isBlackboxDeviceReady()) {
+            blackboxSetState(BLACKBOX_STATE_PREPARE_LOG_FILE);
         }
         break;
     case BLACKBOX_STATE_PREPARE_LOG_FILE:
@@ -2125,7 +2148,13 @@ void blackboxUpdate(timeUs_t currentTimeUs)
             blackboxSetState(BLACKBOX_STATE_STOPPED);
             blackboxStarted = false;
         }
-    break;
+        break;
+    case BLACKBOX_STATE_FULL:
+        if (!blackboxIsLoggingEnabled()) {
+            blackboxDeviceClose();
+            blackboxSetState(BLACKBOX_STATE_STOPPED);
+        }
+        break;
 #endif
     default:
         break;
@@ -2133,8 +2162,8 @@ void blackboxUpdate(timeUs_t currentTimeUs)
 
     // Did we run out of room on the device? Stop!
     if (isBlackboxDeviceFull()) {
-        if (blackboxState < BLACKBOX_STATE_START_ERASE) {
-            blackboxSetState(BLACKBOX_STATE_STOPPED);
+        if (blackboxState == BLACKBOX_STATE_RUNNING) {
+            blackboxSetState(BLACKBOX_STATE_FULL);
         }
     }
 }

--- a/src/main/blackbox/blackbox_io.c
+++ b/src/main/blackbox/blackbox_io.c
@@ -341,7 +341,7 @@ bool blackboxDeviceOpen(void)
         break;
 #ifdef USE_FLASHFS
     case BLACKBOX_DEVICE_FLASH:
-        if (!flashfsIsSupported() || isBlackboxDeviceFull()) {
+        if (!flashfsIsSupported()) {
             return false;
         }
 
@@ -376,18 +376,32 @@ void blackboxDeviceErase(void)
         flashfsEraseCompletely();
     }
 }
+#endif
 
 /**
  * Check to see if erasing is done
  */
 bool isBlackboxDeviceReady(void)
 {
+#ifdef USE_FLASHFS
     if (blackboxConfig()->device == BLACKBOX_DEVICE_FLASH) {
         return flashfsIsReady();
     }
+#endif
     return true;
 }
+
+/**
+ * Perform an initial erase to get some empty space.
+ */
+void blackboxDeviceInitialErase(void)
+{
+#ifdef USE_FLASHFS_LOOP
+    if (blackboxConfig()->device == BLACKBOX_DEVICE_FLASH) {
+        flashfsLoopInitialErase();
+    }
 #endif
+}
 
 /**
  * Close the Blackbox logging device.

--- a/src/main/blackbox/blackbox_io.h
+++ b/src/main/blackbox/blackbox_io.h
@@ -64,3 +64,5 @@ int32_t blackboxGetLogNumber(void);
 void blackboxReplenishHeaderBudget(void);
 blackboxBufferReserveStatus_e blackboxDeviceReserveBufferSpace(int32_t bytes);
 int8_t blackboxGetLogFileNo(void);
+
+void blackboxDeviceInitialErase(void);

--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -2682,9 +2682,11 @@ static void cliFlashInfo(const char *cmdName, char *cmdline)
             FLASH_PARTITION_SECTOR_COUNT(flashPartition) * layout->sectorSize,
             flashfsGetOffset()
     );
+#ifdef USE_FLASHFS_LOOP
     cliPrintLinef("FlashFSLoop Head = 0x%08x, Tail = 0x%08x",
             flashfsGetHeadAddress(),
             flashfsGetTailAddress());
+#endif
 #endif
 }
 

--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -2682,6 +2682,9 @@ static void cliFlashInfo(const char *cmdName, char *cmdline)
             FLASH_PARTITION_SECTOR_COUNT(flashPartition) * layout->sectorSize,
             flashfsGetOffset()
     );
+    cliPrintLinef("FlashFSLoop Head = 0x%08x, Tail = 0x%08x",
+            flashfsGetHeadAddress(),
+            flashfsGetTailAddress());
 #endif
 }
 
@@ -2706,6 +2709,7 @@ static void cliFlashErase(const char *cmdName, char *cmdline)
     flashfsEraseCompletely();
 
     while (!flashfsIsReady()) {
+        flashfsEraseAsync();
 #ifndef MINIMAL_CLI
         cliPrintf(".");
         if (i++ > 120) {
@@ -2723,6 +2727,16 @@ static void cliFlashErase(const char *cmdName, char *cmdline)
 }
 
 #ifdef USE_FLASH_TOOLS
+
+static void cliFlashFill(const char *cmdName, char *cmdline)
+{
+    UNUSED(cmdName);
+    UNUSED(cmdline);
+
+    cliPrintLine("Filling");
+    flashfsFillEntireFlash();
+    cliPrintLine("Done");
+}
 
 static void cliFlashVerify(const char *cmdName, char *cmdline)
 {
@@ -2744,7 +2758,7 @@ static void cliFlashWrite(const char *cmdName, char *cmdline)
     if (!text) {
         cliShowInvalidArgumentCountError(cmdName);
     } else {
-        flashfsSeekAbs(address);
+        flashfsSeekPhysical(address);
         flashfsWrite((uint8_t*)text, strlen(text));
         flashfsFlushSync();
 
@@ -2767,7 +2781,7 @@ static void cliFlashRead(const char *cmdName, char *cmdline)
 
         uint8_t buffer[32];
         while (length > 0) {
-            int bytesRead = flashfsReadAbs(address, buffer, length < sizeof(buffer) ? length : sizeof(buffer));
+            int bytesRead = flashfsReadPhysical(address, buffer, length < sizeof(buffer) ? length : sizeof(buffer));
 
             for (int i = 0; i < bytesRead; i++) {
                 cliWrite(buffer[i]);
@@ -2784,6 +2798,67 @@ static void cliFlashRead(const char *cmdName, char *cmdline)
         cliPrintLinefeed();
     }
 }
+
+static void cliFlashEraseSector(const char *cmdName, char *cmdline)
+{
+    UNUSED(cmdName);
+
+    const char *ptr = cmdline;
+    uint32_t address = atoi(ptr);
+    ptr = nextArg(cmdline);
+    uint32_t length = atoi(ptr);
+
+    const uint32_t sectorSize = flashGetGeometry()->sectorSize;
+    const uint32_t totalSize = flashGetGeometry()->totalSize;
+
+    if (length == 0) {
+        length = 1;
+    }
+
+    // Round down `address`, round up `end_address`, and update `length`
+    uint32_t end_address = address + length;
+    address = address / sectorSize * sectorSize;
+    end_address = (end_address + sectorSize - 1) / sectorSize * sectorSize;
+    length = end_address - address;
+
+    flashSector_t count = length / sectorSize;
+
+    if (address > totalSize - sectorSize) {
+        cliShowArgumentRangeError(cmdName, "address", 0,
+                                  totalSize - sectorSize);
+        return;
+    }
+    if (end_address > totalSize) {
+        cliShowArgumentRangeError(cmdName, "length", sectorSize,
+                                  totalSize - address);
+        return;
+    }
+    timeUs_t start = micros();
+    for (uint32_t i = 0; i < count; i++) {
+        flashEraseSector(address + i * sectorSize);
+        flashWaitForReady();
+    }
+    timeUs_t end = micros();
+    cliPrintLinef("Erased address %u length %u (%u sectors) in %u us", address,
+                  length, count, end - start);
+}
+
+#ifdef USE_FLASHFS_LOOP
+static void cliFlashfsInitialErase(const char *cmdName, char *cmdline)
+{
+    UNUSED(cmdName);
+    UNUSED(cmdline);
+    flashfsInit();
+
+    timeUs_t start = micros();
+    flashfsLoopInitialErase();
+    while(!flashfsIsReady()) {
+        flashfsEraseAsync();
+    }
+    timeUs_t end = micros();
+    cliPrintLinef("FlashfsInitialErase %u us", end - start);
+}
+#endif  // USE_FLASHFS_LOOP
 
 #endif
 #endif
@@ -6429,8 +6504,13 @@ const clicmd_t cmdTable[] = {
     CLI_COMMAND_DEF("flash_info", "show flash chip info", NULL, cliFlashInfo),
 #ifdef USE_FLASH_TOOLS
     CLI_COMMAND_DEF("flash_read", NULL, "<length> <address>", cliFlashRead),
-    CLI_COMMAND_DEF("flash_scan", "scan flash device for errors", NULL, cliFlashVerify),
+    CLI_COMMAND_DEF("flash_fill", "fill device with predefined pattern", NULL, cliFlashFill),
+    CLI_COMMAND_DEF("flash_verify", "verify device with predefined pattern", NULL, cliFlashVerify),
     CLI_COMMAND_DEF("flash_write", NULL, "<address> <message>", cliFlashWrite),
+    CLI_COMMAND_DEF("flash_erase_sector", "erase flash sector(s)", "<address> [<length>]", cliFlashEraseSector),
+#ifdef USE_FLASHFS_LOOP
+    CLI_COMMAND_DEF("flashfs_initial_erase", "invoke initial erase", NULL, cliFlashfsInitialErase),
+#endif  // USE_FLASHFS_LOOP
 #endif
 #endif
     CLI_COMMAND_DEF("get", "get variable value", "[name]", cliGet),

--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -805,6 +805,7 @@ const clivalue_t valueTable[] = {
 
 #ifdef USE_FLASHFS_LOOP
     { "blackbox_initial_erase_kb",  VAR_UINT16 | MASTER_VALUE, .config.minmaxUnsigned = { 0, UINT16_MAX }, PG_BLACKBOX_CONFIG, offsetof(blackboxConfig_t, initialEraseFreeSpaceKiB) },
+    { "blackbox_rolling_erase",     VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_BLACKBOX_CONFIG, offsetof(blackboxConfig_t, rollingErase) },
 #endif
 #endif
 
@@ -1753,7 +1754,7 @@ const clivalue_t valueTable[] = {
     { "sbus_out_source_range_low",  VAR_INT16 | MASTER_VALUE | MODE_ARRAY, .config.array.length = SBUS_OUT_CHANNELS, PG_DRIVER_SBUS_OUT_CONFIG, offsetof(sbusOutConfig_t, sourceRangeLow) },
     { "sbus_out_source_range_high", VAR_INT16 | MASTER_VALUE | MODE_ARRAY, .config.array.length = SBUS_OUT_CHANNELS, PG_DRIVER_SBUS_OUT_CONFIG, offsetof(sbusOutConfig_t, sourceRangeHigh) },
     { "sbus_out_frame_rate",        VAR_UINT8 | MASTER_VALUE, .config.minmaxUnsigned = {25, 250}, PG_DRIVER_SBUS_OUT_CONFIG, offsetof(sbusOutConfig_t, frameRate) },
-    { "sbus_out_pinswap",           VAR_UINT8 | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON}, PG_DRIVER_SBUS_OUT_CONFIG, offsetof(sbusOutConfig_t, pinSwap) },
+    { "sbus_out_pinswap",           VAR_UINT8 | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_DRIVER_SBUS_OUT_CONFIG, offsetof(sbusOutConfig_t, pinSwap) },
 #endif
 };
 

--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -804,7 +804,7 @@ const clivalue_t valueTable[] = {
     { "blackbox_log_esc2",          VAR_UINT32 | MASTER_VALUE | MODE_BITSET, .config.bitpos = FLIGHT_LOG_FIELD_SELECT_ESC2, PG_BLACKBOX_CONFIG, offsetof(blackboxConfig_t, fields) },
 
 #ifdef USE_FLASHFS_LOOP
-    { "blackbox_initial_erase",     VAR_UINT32 | MASTER_VALUE, .config.u32Max = UINT32_MAX, PG_BLACKBOX_CONFIG, offsetof(blackboxConfig_t, initialEraseFreeSpace) },
+    { "blackbox_initial_erase_kb",  VAR_UINT16 | MASTER_VALUE, .config.minmaxUnsigned = { 0, UINT16_MAX }, PG_BLACKBOX_CONFIG, offsetof(blackboxConfig_t, initialEraseFreeSpaceKiB) },
 #endif
 #endif
 

--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -802,6 +802,10 @@ const clivalue_t valueTable[] = {
     { "blackbox_log_esc",           VAR_UINT32 | MASTER_VALUE | MODE_BITSET, .config.bitpos = FLIGHT_LOG_FIELD_SELECT_ESC, PG_BLACKBOX_CONFIG, offsetof(blackboxConfig_t, fields) },
     { "blackbox_log_bec",           VAR_UINT32 | MASTER_VALUE | MODE_BITSET, .config.bitpos = FLIGHT_LOG_FIELD_SELECT_BEC, PG_BLACKBOX_CONFIG, offsetof(blackboxConfig_t, fields) },
     { "blackbox_log_esc2",          VAR_UINT32 | MASTER_VALUE | MODE_BITSET, .config.bitpos = FLIGHT_LOG_FIELD_SELECT_ESC2, PG_BLACKBOX_CONFIG, offsetof(blackboxConfig_t, fields) },
+
+#ifdef USE_FLASHFS_LOOP
+    { "blackbox_initial_erase",     VAR_UINT32 | MASTER_VALUE, .config.u32Max = UINT32_MAX, PG_BLACKBOX_CONFIG, offsetof(blackboxConfig_t, initialEraseFreeSpace) },
+#endif
 #endif
 
 // PG_MOTOR_CONFIG

--- a/src/main/fc/core.c
+++ b/src/main/fc/core.c
@@ -110,7 +110,6 @@
 
 #include "core.h"
 
-
 enum {
     ALIGN_GYRO = 0,
     ALIGN_ACCEL = 1,

--- a/src/main/io/flashfs.c
+++ b/src/main/io/flashfs.c
@@ -773,9 +773,9 @@ void flashfsLoopInitialErase()
         return;
     }
 
-    const int32_t bytesNeeded = flashfsGetOffset() +
-                                blackboxConfig()->initialEraseFreeSpace -
-                                flashfsSize;
+    const int32_t bytesNeeded =
+        flashfsGetOffset() + blackboxConfig()->initialEraseFreeSpaceKiB * 1024 -
+        flashfsSize;
 
     if (bytesNeeded <= 0) {
         return;

--- a/src/main/io/flashfs.c
+++ b/src/main/io/flashfs.c
@@ -51,10 +51,21 @@
 
 #include "pg/blackbox.h"
 
+/*
+ * How background erase works:
+ *   1. When start programming (flush) a page, if erase is needed and can be
+ *      started, set FLASHFS_ROLLING_ERASE_PENDING.
+ *   2. No more flush can be done when FLASHFS_ROLLING_ERASE_PENDING.
+ *   3. When page program finishes, EraseAsync task picks up the erase task and
+ *      sets FLASHFS_ROLLING_ERASING.
+ *   4. When erase finishes, EraseAsync task resets state to FLASHFS_IDLE.
+ */
 typedef enum {
     FLASHFS_IDLE,
     FLASHFS_ALL_ERASING,
     FLASHFS_INITIAL_ERASING,
+    FLASHFS_ROLLING_ERASE_PENDING,
+    FLASHFS_ROLLING_ERASING,
 } flashfsState_e;
 
 static const flashPartition_t *flashPartition = NULL;
@@ -268,22 +279,76 @@ static uint32_t flashfsWriteBuffers(uint8_t const **buffers, uint32_t *bufferSiz
 
     // It's OK to overwrite the buffer addresses/lengths being passed in
 
-    // If sync is true, block until the FLASH device is ready, otherwise return 0 if the device isn't ready
+    // If sync is true, block until the FLASH device is ready, otherwise return
+    // 0 if the device isn't ready
     if (sync) {
         while (!flashIsReady());
+        /*
+         * Wait for any flashfs erase to complete.
+         * Note: we shouldn't reach inside since there's no such real world
+         * scenario (sync = 1 and flashfsState != FLASHFS_IDLE).
+         */
+        while (flashfsState != FLASHFS_IDLE) {
+            flashfsEraseAsync();
+        }
     } else {
         if (!flashIsReady()) {
+            return 0;
+        }
+        /*
+         * Also bail out if we are running any of the erases.
+         * There are a few cases:
+         *   * FLASHFS_ARMING_ERASING: logging is running ("switch" mode) and
+         *     arming erase has triggered or running. We can't write.
+         *   * FLASHFS_ROLLING_ERASE_PENDING: background erase is pending. We
+         *     can't write. (If we write, those bytes will be discarded on
+         *     erase).
+         *   * FLASHFS_ROLLING_ERASING: technically we can write (under this
+         *     state and flashIsReady()), because background erase erases only 1
+         *     sector. For simplicity, we wait for the task to update the state.
+         *   * FLASHFS_ALL_ERASING: we can't write. We may land between erase
+         *     sectors.
+         */
+        if (flashfsState != FLASHFS_IDLE) {
             return 0;
         }
     }
 
     // Are we at EOF already? Abort.
     if (flashfsIsEOF()) {
+#ifdef USE_FLASHFS_LOOP
+        // If EOF, request an background erase unconditionally
+        if (blackboxConfig()->rollingErase) {
+            flashfsState = FLASHFS_ROLLING_ERASE_PENDING;
+        }
+#endif
         return 0;
     }
 
 #ifdef CHECK_FLASH
     checkFlashPtr = tailAddress;
+#endif
+
+#ifdef USE_FLASHFS_LOOP
+    // Check if background erase is needed. Why here? Because we can only
+    // erase when a page (aligned) program is completed.
+    const uint32_t freeSpace = flashfsSize - flashfsGetOffset();
+    if (blackboxConfig()->rollingErase &&
+        freeSpace < flashGeometry->sectorSize) {
+        // See if we are finishing a page.
+        uint32_t bytes_to_write = 0;
+        if (bufferCount > 0)
+            bytes_to_write += bufferSizes[0];
+        if (bufferCount > 1)
+            bytes_to_write += bufferSizes[1];
+        if (tailAddress / flashGeometry->pageSize !=
+            (tailAddress + bytes_to_write) / flashGeometry->pageSize) {
+            // We will write to or write over a page boundary. We can erase when
+            // this write is done.
+            flashfsState = FLASHFS_ROLLING_ERASE_PENDING;
+        }
+    }
+
 #endif
 
     flashPageProgramBegin(tailAddress, flashfsWriteCallback);
@@ -448,6 +513,9 @@ void flashfsEraseAsync(void)
             if (initialEraseSectors > 0) {
                 flashEraseSector(headAddress);
                 initialEraseSectors--;
+                // We immediately set the head before erase is completed.
+                // This should be fine since write will be blocked until this
+                // state is cleared.
                 headAddress =
                     flashfsAddressShift(headAddress, flashGeometry->sectorSize);
                 LED1_TOGGLE;
@@ -455,8 +523,24 @@ void flashfsEraseAsync(void)
                 flashfsState = FLASHFS_IDLE;
                 LED1_OFF;
             }
+        } else if (flashfsState == FLASHFS_ROLLING_ERASE_PENDING) {
+            flashEraseSector(headAddress);
+            headAddress =
+                flashfsAddressShift(headAddress, flashGeometry->sectorSize);
+            flashfsState = FLASHFS_ROLLING_ERASING;
+            LED1_TOGGLE;
+        } else if (flashfsState == FLASHFS_ROLLING_ERASING) {
+            flashfsState = FLASHFS_IDLE;
+            LED1_OFF;
         }
     }
+}
+
+void flashfsSeekAbs(uint32_t offset)
+{
+    flashfsFlushSync();
+
+    flashfsSetTailAddress(flashfsAddressShift(headAddress, offset));
 }
 
 void flashfsSeekPhysical(uint32_t offset)
@@ -706,6 +790,8 @@ void flashfsInit(void)
 
     // Start the file pointer off at the beginning of free space so caller can start writing immediately
     flashfsSeekPhysical(flashfsIdentifyStartOfFreeSpace());
+
+    flashfsState = FLASHFS_IDLE;
 }
 
 #ifdef USE_FLASH_TOOLS

--- a/src/main/io/flashfs.c
+++ b/src/main/io/flashfs.c
@@ -32,6 +32,10 @@
  * and make calls through that, at the moment flashfs just calls m25p16_* routines explicitly.
  */
 
+/**
+ * With USE_FLASHFS_LOOP enabled, the data stream will be wrapped. Flashfs will
+ * keep at least 1 page free to identify the stream start and stream end.
+ */
 #include <stdint.h>
 #include <stdbool.h>
 #include <string.h>
@@ -45,16 +49,20 @@
 
 #include "io/flashfs.h"
 
+#include "pg/blackbox.h"
+
 typedef enum {
     FLASHFS_IDLE,
-    FLASHFS_ERASING,
+    FLASHFS_ALL_ERASING,
+    FLASHFS_INITIAL_ERASING,
 } flashfsState_e;
 
 static const flashPartition_t *flashPartition = NULL;
 static const flashGeometry_t *flashGeometry = NULL;
-static uint32_t flashfsSize = 0;
+STATIC_UNIT_TESTED uint32_t flashfsSize = 0;
 static flashfsState_e flashfsState = FLASHFS_IDLE;
 static flashSector_t eraseSectorCurrent = 0;
+static uint16_t initialEraseSectors = 0;
 
 static DMA_DATA_ZERO_INIT uint8_t flashWriteBuffer[FLASHFS_WRITE_BUFFER_SIZE];
 
@@ -92,8 +100,18 @@ uint8_t checkFlashExpected = 0x00;
 uint32_t checkFlashErrors = 0;
 #endif
 
+// The position of head address. headAddress can only be at sector boundary.
+STATIC_UNIT_TESTED uint32_t headAddress = 0;
 // The position of the buffer's tail in the overall flash address space:
-static uint32_t tailAddress = 0;
+STATIC_UNIT_TESTED uint32_t tailAddress = 0;
+
+static inline uint32_t flashfsAddressShift(uint32_t address, int32_t offset) {
+#ifdef USE_FLASHFS_LOOP
+    return (address + offset + flashfsSize) % flashfsSize;
+#else
+    return address + offset;
+#endif
+}
 
 static void flashfsClearBuffer(void)
 {
@@ -120,12 +138,13 @@ void flashfsEraseCompletely(void)
         } else {
             // start asynchronous erase of all sectors
             eraseSectorCurrent = flashPartition->startSector;
-            flashfsState = FLASHFS_ERASING;
+            flashfsState = FLASHFS_ALL_ERASING;
         }
     }
 
     flashfsClearBuffer();
 
+    headAddress = 0;
     flashfsSetTailAddress(0);
 }
 
@@ -234,7 +253,7 @@ static void flashfsAdvanceTailInBuffer(uint32_t delta)
 void flashfsWriteCallback(uint32_t arg)
 {
     // Advance the cursor in the file system to match the bytes we wrote
-    flashfsSetTailAddress(tailAddress + arg);
+    flashfsSetTailAddress(flashfsAddressShift(tailAddress, arg));
 
     // Free bytes in the ring buffer
     flashfsAdvanceTailInBuffer(arg);
@@ -324,7 +343,7 @@ static bool flashfsNewData()
 
 
 /**
- * Get the current offset of the file pointer within the volume.
+ * Get the current usage of the volume, including the buffered ones.
  */
 uint32_t flashfsGetOffset(void)
 {
@@ -335,7 +354,8 @@ uint32_t flashfsGetOffset(void)
 
     flashfsGetDirtyDataBuffers(buffers, bufferSizes);
 
-    return tailAddress + bufferSizes[0] + bufferSizes[1];
+    return flashfsAddressShift(tailAddress + bufferSizes[0] + bufferSizes[1],
+                               -headAddress);
 }
 
 /**
@@ -410,11 +430,12 @@ void flashfsFlushSync(void)
  */
 void flashfsEraseAsync(void)
 {
-    if (flashfsState == FLASHFS_ERASING) {
-        if ((flashfsIsSupported() && flashIsReady())) {
+    if ((flashfsIsSupported() && flashIsReady())) {
+        if (flashfsState == FLASHFS_ALL_ERASING) {
             if (eraseSectorCurrent <= flashPartition->endSector) {
                 // Erase sector
-                uint32_t sectorAddress = eraseSectorCurrent * flashGeometry->sectorSize;
+                uint32_t sectorAddress =
+                    eraseSectorCurrent * flashGeometry->sectorSize;
                 flashEraseSector(sectorAddress);
                 eraseSectorCurrent++;
                 LED1_TOGGLE;
@@ -423,11 +444,22 @@ void flashfsEraseAsync(void)
                 flashfsState = FLASHFS_IDLE;
                 LED1_OFF;
             }
+        } else if (flashfsState == FLASHFS_INITIAL_ERASING) {
+            if (initialEraseSectors > 0) {
+                flashEraseSector(headAddress);
+                initialEraseSectors--;
+                headAddress =
+                    flashfsAddressShift(headAddress, flashGeometry->sectorSize);
+                LED1_TOGGLE;
+            } else {
+                flashfsState = FLASHFS_IDLE;
+                LED1_OFF;
+            }
         }
     }
 }
 
-void flashfsSeekAbs(uint32_t offset)
+void flashfsSeekPhysical(uint32_t offset)
 {
     flashfsFlushSync();
 
@@ -465,11 +497,11 @@ void flashfsWrite(const uint8_t *data, unsigned int len)
 }
 
 /**
- * Read `len` bytes from the given address into the supplied buffer.
+ * Read `len` bytes from the given physical address into the supplied buffer.
  *
  * Returns the number of bytes actually read which may be less than that requested.
  */
-int flashfsReadAbs(uint32_t address, uint8_t *buffer, unsigned int len)
+int flashfsReadPhysical(uint32_t address, uint8_t *buffer, unsigned int len)
 {
     int bytesRead;
 
@@ -488,7 +520,63 @@ int flashfsReadAbs(uint32_t address, uint8_t *buffer, unsigned int len)
 }
 
 /**
- * Find the offset of the start of the free space on the device (or the size of the device if it is full).
+ * Read `len` bytes from the given address into the supplied buffer.
+ *
+ * Returns the number of bytes actually read which may be less than that requested.
+ */
+int flashfsReadAbs(uint32_t address, uint8_t *buffer, unsigned int len)
+{
+    uint32_t physicalAddress = flashfsAddressShift(headAddress, address);
+    uint16_t len1 = len, len2 = 0;
+    int bytesRead;
+
+    // Wrapped read?
+    if (physicalAddress + len1 > flashfsSize) {
+        len1 = flashfsSize - physicalAddress;
+        len2 = len - len1;
+    }
+
+    flashfsFlushSync();
+
+    bytesRead = flashReadBytes(physicalAddress, buffer, len1);
+    if (len2) {
+        // Second section
+        bytesRead += flashReadBytes(0, buffer + len1, len2);
+    }
+
+    return bytesRead;
+}
+
+// This function takes a physical address
+static bool flashfsIsPageErased(uint32_t address){
+    enum {
+        /* We don't expect valid data to ever contain this many consecutive uint32_t's of all 1 bits: */
+        EMPTY_PAGE_TEST_SIZE_INTS = 4, // i.e. 16 bytes
+        EMPTY_PAGE_TEST_SIZE_BYTES = EMPTY_PAGE_TEST_SIZE_INTS * sizeof(uint32_t)
+    };
+
+    STATIC_DMA_DATA_AUTO union {
+        uint8_t bytes[EMPTY_PAGE_TEST_SIZE_BYTES];
+        uint32_t ints[EMPTY_PAGE_TEST_SIZE_INTS];
+    } testBuffer;
+
+    if (flashReadBytes(address, testBuffer.bytes, EMPTY_PAGE_TEST_SIZE_BYTES) < EMPTY_PAGE_TEST_SIZE_BYTES) {
+        // Unexpected timeout from flash, so bail early (reporting the device fuller than it really is)
+        return false;
+    }
+
+    // Checking the buffer 4 bytes at a time like this is probably faster than byte-by-byte, but I didn't benchmark it :)
+    for (uint8_t i = 0; i < EMPTY_PAGE_TEST_SIZE_INTS; i++) {
+        if (testBuffer.ints[i] != 0xFFFFFFFF) {
+            return false;
+        }
+    }
+    return true;
+}
+
+/**
+ * Find the absolute address of the start of the free space on the device.
+ * `headAddress` must be setup prior to this function.
  */
 int flashfsIdentifyStartOfFreeSpace(void)
 {
@@ -501,50 +589,26 @@ int flashfsIdentifyStartOfFreeSpace(void)
      * bandwidth and block more often.
      */
 
-    enum {
-        /* We can choose whatever power of 2 size we like, which determines how much wastage of free space we'll have
-         * at the end of the last written data. But smaller blocksizes will require more searching.
-         */
-        FREE_BLOCK_SIZE = 2048, // XXX This can't be smaller than page size for underlying flash device.
 
-        /* We don't expect valid data to ever contain this many consecutive uint32_t's of all 1 bits: */
-        FREE_BLOCK_TEST_SIZE_INTS = 4, // i.e. 16 bytes
-        FREE_BLOCK_TEST_SIZE_BYTES = FREE_BLOCK_TEST_SIZE_INTS * sizeof(uint32_t)
-    };
+    const uint16_t pageSize = flashGeometry->pageSize;
 
-    STATIC_ASSERT(FREE_BLOCK_SIZE >= FLASH_MAX_PAGE_SIZE, FREE_BLOCK_SIZE_too_small);
-
-    STATIC_DMA_DATA_AUTO union {
-        uint8_t bytes[FREE_BLOCK_TEST_SIZE_BYTES];
-        uint32_t ints[FREE_BLOCK_TEST_SIZE_INTS];
-    } testBuffer;
-
-    int left = 0; // Smallest block index in the search region
-    int right = flashfsSize / FREE_BLOCK_SIZE; // One past the largest block index in the search region
+    int left = 0; // Smallest page index in the search region
+    int right = flashfsSize / pageSize; // One past the largest page index in the search region
+#ifdef USE_FLASHFS_LOOP
+    right--;
+    // We must leave one empty page to:
+    //  1. identify empty space
+    //  2. differenciate between full and empty
+#endif
     int mid;
     int result = right;
-    int i;
-    bool blockErased;
 
     while (left < right) {
         mid = (left + right) / 2;
 
-        if (flashReadBytes(mid * FREE_BLOCK_SIZE, testBuffer.bytes, FREE_BLOCK_TEST_SIZE_BYTES) < FREE_BLOCK_TEST_SIZE_BYTES) {
-            // Unexpected timeout from flash, so bail early (reporting the device fuller than it really is)
-            break;
-        }
-
-        // Checking the buffer 4 bytes at a time like this is probably faster than byte-by-byte, but I didn't benchmark it :)
-        blockErased = true;
-        for (i = 0; i < FREE_BLOCK_TEST_SIZE_INTS; i++) {
-            if (testBuffer.ints[i] != 0xFFFFFFFF) {
-                blockErased = false;
-                break;
-            }
-        }
-
-        if (blockErased) {
-            /* This erased block might be the leftmost erased block in the volume, but we'll need to continue the
+        uint32_t address = flashfsAddressShift(headAddress, mid * pageSize);
+        if (flashfsIsPageErased(address)) {
+            /* This empty page might be the leftmost empty page in the volume, but we'll need to continue the
              * search leftwards to find out:
              */
             result = mid;
@@ -555,7 +619,7 @@ int flashfsIdentifyStartOfFreeSpace(void)
         }
     }
 
-    return result * FREE_BLOCK_SIZE;
+    return flashfsAddressShift(headAddress, result * pageSize);
 }
 
 /**
@@ -563,7 +627,18 @@ int flashfsIdentifyStartOfFreeSpace(void)
  */
 bool flashfsIsEOF(void)
 {
+#ifdef USE_FLASHFS_LOOP
+    // In case of using LOOP_FLASHFS, we need
+    //  * 1 free page before a sector to identify boundary.
+    //  * +flashfs buffer size to avoid writing to that 1 free page.
+    uint32_t persistedBytes = flashfsAddressShift(tailAddress, -headAddress);
+
+    return persistedBytes >=
+           flashfsSize - flashGeometry->pageSize - FLASHFS_WRITE_BUFFER_SIZE;
+
+#else
     return tailAddress >= flashfsSize;
+#endif
 }
 
 void flashfsClose(void)
@@ -572,11 +647,41 @@ void flashfsClose(void)
         case FLASH_TYPE_NAND:
             flashFlush();
             /* FALL THROUGH */
-        case FLASH_TYPE_NOR:
+        case FLASH_TYPE_NOR: {
             flashfsClearBuffer();
-            flashfsSetTailAddress((tailAddress + 2047) & ~2047);
+
+            const uint16_t pageSize = flashGeometry->pageSize;
+            const uint32_t padding = (tailAddress % pageSize == 0
+                                          ? 0
+                                          : pageSize - tailAddress % pageSize);
+
+            flashfsSetTailAddress(flashfsAddressShift(tailAddress, padding));
             break;
+        }
     }
+}
+
+/*
+ * Locate the start physical address of the used space. Return 0 if all space
+ * are unused.
+ */
+uint32_t flashfsIdentifyStartOfUsedSpace() {
+    // Locate the boundary between erased and filled.
+    // This can only be at the sector boundary.
+
+    // We skip the startSector because the calculation is a bit different and we
+    // will use that as fallback.
+    for (uint16_t sector = flashPartition->startSector + 1;
+         sector <= flashPartition->endSector; sector++) {
+        uint32_t startAddress = sector * flashGeometry->sectorSize;
+        uint32_t endAddress = startAddress - flashGeometry->pageSize;
+        if (flashfsIsPageErased(endAddress) && !flashfsIsPageErased(startAddress)) {
+            return sector * flashGeometry->sectorSize;
+        }
+    }
+
+    // fallback
+    return flashPartition->startSector * flashGeometry->sectorSize;
 }
 
 /**
@@ -595,18 +700,26 @@ void flashfsInit(void)
 
     flashfsSize = FLASH_PARTITION_SECTOR_COUNT(flashPartition) * flashGeometry->sectorSize;
 
+#ifdef USE_FLASHFS_LOOP
+    headAddress = flashfsIdentifyStartOfUsedSpace();
+#endif
+
     // Start the file pointer off at the beginning of free space so caller can start writing immediately
-    flashfsSeekAbs(flashfsIdentifyStartOfFreeSpace());
+    flashfsSeekPhysical(flashfsIdentifyStartOfFreeSpace());
 }
 
 #ifdef USE_FLASH_TOOLS
-bool flashfsVerifyEntireFlash(void)
+
+void flashfsFillEntireFlash(void)
 {
     flashfsEraseCompletely();
+    while(flashfsState != FLASHFS_IDLE) {
+        flashfsEraseAsync();
+    }
     flashfsInit();
 
     uint32_t address = 0;
-    flashfsSeekAbs(address);
+    flashfsSeekPhysical(address);
 
     const int bufferSize = 32;
     char buffer[bufferSize + 1];
@@ -616,20 +729,33 @@ bool flashfsVerifyEntireFlash(void)
     for (address = 0; address < testLimit; address += bufferSize) {
         tfp_sprintf(buffer, "%08x >> **0123456789ABCDEF**", address);
         flashfsWrite((uint8_t*)buffer, strlen(buffer));
+        flashfsFlushSync();
     }
-    flashfsFlushSync();
     flashfsClose();
+}
 
+bool flashfsVerifyEntireFlash(void)
+{
+    flashfsInit();
+    uint32_t address = 0;
+
+    const int bufferSize = 32;
+    char buffer[bufferSize + 1];
+
+    uint32_t testLimit = flashfsGetSize();
+#ifdef USE_FLASHFS_LOOP
+    testLimit -= flashGeometry->pageSize + FLASHFS_WRITE_BUFFER_SIZE;
+#endif
     char expectedBuffer[bufferSize + 1];
 
-    flashfsSeekAbs(0);
+    flashfsSeekPhysical(0);
 
     int verificationFailures = 0;
     for (address = 0; address < testLimit; address += bufferSize) {
         tfp_sprintf(expectedBuffer, "%08x >> **0123456789ABCDEF**", address);
 
         memset(buffer, 0, sizeof(buffer));
-        int bytesRead = flashfsReadAbs(address, (uint8_t *)buffer, bufferSize);
+        int bytesRead = flashfsReadPhysical(address, (uint8_t *)buffer, bufferSize);
 
         int result = strncmp(buffer, expectedBuffer, bufferSize);
         if (result != 0 || bytesRead != bufferSize) {
@@ -639,3 +765,34 @@ bool flashfsVerifyEntireFlash(void)
     return verificationFailures == 0;
 }
 #endif // USE_FLASH_TOOLS
+
+#ifdef USE_FLASHFS_LOOP
+void flashfsLoopInitialErase()
+{
+    if (flashfsState != FLASHFS_IDLE) {
+        return;
+    }
+
+    const int32_t bytesNeeded = flashfsGetOffset() +
+                                blackboxConfig()->initialEraseFreeSpace -
+                                flashfsSize;
+
+    if (bytesNeeded <= 0) {
+        return;
+    }
+    const uint32_t sectorSize = flashGeometry->sectorSize;
+    initialEraseSectors = (bytesNeeded + sectorSize - 1) / sectorSize;
+
+    flashfsState = FLASHFS_INITIAL_ERASING;
+}
+#endif
+
+uint32_t flashfsGetHeadAddress()
+{
+    return headAddress;
+}
+
+uint32_t flashfsGetTailAddress()
+{
+    return tailAddress;
+}

--- a/src/main/io/flashfs.h
+++ b/src/main/io/flashfs.h
@@ -58,7 +58,7 @@ bool flashfsVerifyEntireFlash(void);
 
 #ifdef USE_FLASHFS_LOOP
 void flashfsLoopInitialErase();
-#endif
 
 uint32_t flashfsGetHeadAddress();
 uint32_t flashfsGetTailAddress();
+#endif

--- a/src/main/io/flashfs.h
+++ b/src/main/io/flashfs.h
@@ -34,12 +34,13 @@ int flashfsIdentifyStartOfFreeSpace(void);
 struct flashGeometry_s;
 const struct flashGeometry_s* flashfsGetGeometry(void);
 
-void flashfsSeekAbs(uint32_t offset);
+void flashfsSeekPhysical(uint32_t offset);
 
 void flashfsWriteByte(uint8_t byte);
 void flashfsWrite(const uint8_t *data, unsigned int len);
 
 int flashfsReadAbs(uint32_t offset, uint8_t *data, unsigned int len);
+int flashfsReadPhysical(uint32_t offset, uint8_t *data, unsigned int len);
 
 bool flashfsFlushAsync(void);
 void flashfsFlushSync(void);
@@ -52,5 +53,12 @@ bool flashfsIsSupported(void);
 bool flashfsIsReady(void);
 bool flashfsIsEOF(void);
 
+void flashfsFillEntireFlash(void);
 bool flashfsVerifyEntireFlash(void);
 
+#ifdef USE_FLASHFS_LOOP
+void flashfsLoopInitialErase();
+#endif
+
+uint32_t flashfsGetHeadAddress();
+uint32_t flashfsGetTailAddress();

--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -1007,7 +1007,7 @@ static bool mspCommonProcessOutCommand(int16_t cmdMSP, sbuf_t *dst, mspPostProce
     }
 
     case MSP_EXPERIMENTAL:
-        /* 
+        /*
          * Send your experimental parameters to LUA. Like:
          *
          * sbufWriteU8(dst, currentPidProfile->yourFancyParameterA);
@@ -1721,11 +1721,13 @@ static bool mspProcessOutCommand(int16_t cmdMSP, sbuf_t *dst)
         sbufWriteU8(dst, blackboxConfig()->mode);
         sbufWriteU16(dst, blackboxConfig()->denom);
         sbufWriteU32(dst, blackboxConfig()->fields);
+        sbufWriteU32(dst, blackboxConfig()->initialEraseFreeSpace);
 #else
         sbufWriteU8(dst, 0); // Blackbox not supported
         sbufWriteU8(dst, 0);
         sbufWriteU8(dst, 0);
         sbufWriteU16(dst, 0);
+        sbufWriteU32(dst, 0);
         sbufWriteU32(dst, 0);
 #endif
         break;
@@ -2762,6 +2764,10 @@ static mspResult_e mspProcessInCommand(mspDescriptor_t srcDesc, int16_t cmdMSP, 
             blackboxConfigMutable()->mode = sbufReadU8(src);
             blackboxConfigMutable()->denom = sbufReadU16(src);
             blackboxConfigMutable()->fields = sbufReadU32(src);
+            if (sbufBytesRemaining(src) >= 4) {
+                blackboxConfigMutable()->initialEraseFreeSpace =
+                    sbufReadU32(src);
+            }
         }
         break;
 #endif

--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -1721,14 +1721,14 @@ static bool mspProcessOutCommand(int16_t cmdMSP, sbuf_t *dst)
         sbufWriteU8(dst, blackboxConfig()->mode);
         sbufWriteU16(dst, blackboxConfig()->denom);
         sbufWriteU32(dst, blackboxConfig()->fields);
-        sbufWriteU32(dst, blackboxConfig()->initialEraseFreeSpace);
+        sbufWriteU16(dst, blackboxConfig()->initialEraseFreeSpaceKiB);
 #else
         sbufWriteU8(dst, 0); // Blackbox not supported
         sbufWriteU8(dst, 0);
         sbufWriteU8(dst, 0);
         sbufWriteU16(dst, 0);
         sbufWriteU32(dst, 0);
-        sbufWriteU32(dst, 0);
+        sbufWriteU16(dst, 0);
 #endif
         break;
 
@@ -2764,9 +2764,9 @@ static mspResult_e mspProcessInCommand(mspDescriptor_t srcDesc, int16_t cmdMSP, 
             blackboxConfigMutable()->mode = sbufReadU8(src);
             blackboxConfigMutable()->denom = sbufReadU16(src);
             blackboxConfigMutable()->fields = sbufReadU32(src);
-            if (sbufBytesRemaining(src) >= 4) {
-                blackboxConfigMutable()->initialEraseFreeSpace =
-                    sbufReadU32(src);
+            if (sbufBytesRemaining(src) >= 2) {
+                blackboxConfigMutable()->initialEraseFreeSpaceKiB =
+                    sbufReadU16(src);
             }
         }
         break;

--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -1722,6 +1722,7 @@ static bool mspProcessOutCommand(int16_t cmdMSP, sbuf_t *dst)
         sbufWriteU16(dst, blackboxConfig()->denom);
         sbufWriteU32(dst, blackboxConfig()->fields);
         sbufWriteU16(dst, blackboxConfig()->initialEraseFreeSpaceKiB);
+        sbufWriteU8(dst, blackboxConfig()->rollingErase);
 #else
         sbufWriteU8(dst, 0); // Blackbox not supported
         sbufWriteU8(dst, 0);
@@ -1729,6 +1730,7 @@ static bool mspProcessOutCommand(int16_t cmdMSP, sbuf_t *dst)
         sbufWriteU16(dst, 0);
         sbufWriteU32(dst, 0);
         sbufWriteU16(dst, 0);
+        sbufWriteU8(dst, 0);
 #endif
         break;
 
@@ -2767,6 +2769,9 @@ static mspResult_e mspProcessInCommand(mspDescriptor_t srcDesc, int16_t cmdMSP, 
             if (sbufBytesRemaining(src) >= 2) {
                 blackboxConfigMutable()->initialEraseFreeSpaceKiB =
                     sbufReadU16(src);
+            }
+            if (sbufBytesRemaining(src) >= 1) {
+                blackboxConfigMutable()->rollingErase = sbufReadU8(src);
             }
         }
         break;

--- a/src/main/pg/blackbox.c
+++ b/src/main/pg/blackbox.c
@@ -53,6 +53,7 @@ PG_RESET_TEMPLATE(blackboxConfig_t, blackboxConfig,
               BIT(FLIGHT_LOG_FIELD_SELECT_MOTOR) |
               BIT(FLIGHT_LOG_FIELD_SELECT_SERVO),
     .initialEraseFreeSpaceKiB = 0,
+    .rollingErase = 0,
 );
 
 #endif

--- a/src/main/pg/blackbox.c
+++ b/src/main/pg/blackbox.c
@@ -52,6 +52,7 @@ PG_RESET_TEMPLATE(blackboxConfig_t, blackboxConfig,
               BIT(FLIGHT_LOG_FIELD_SELECT_RPM) |
               BIT(FLIGHT_LOG_FIELD_SELECT_MOTOR) |
               BIT(FLIGHT_LOG_FIELD_SELECT_SERVO),
+    .initialEraseFreeSpace = 0,
 );
 
 #endif

--- a/src/main/pg/blackbox.c
+++ b/src/main/pg/blackbox.c
@@ -52,7 +52,7 @@ PG_RESET_TEMPLATE(blackboxConfig_t, blackboxConfig,
               BIT(FLIGHT_LOG_FIELD_SELECT_RPM) |
               BIT(FLIGHT_LOG_FIELD_SELECT_MOTOR) |
               BIT(FLIGHT_LOG_FIELD_SELECT_SERVO),
-    .initialEraseFreeSpace = 0,
+    .initialEraseFreeSpaceKiB = 0,
 );
 
 #endif

--- a/src/main/pg/blackbox.h
+++ b/src/main/pg/blackbox.h
@@ -44,6 +44,7 @@ typedef struct blackboxConfig_s {
     uint16_t    denom;
     uint32_t    fields;
     uint16_t    initialEraseFreeSpaceKiB;
+    uint8_t     rollingErase;
 } blackboxConfig_t;
 
 PG_DECLARE(blackboxConfig_t, blackboxConfig);

--- a/src/main/pg/blackbox.h
+++ b/src/main/pg/blackbox.h
@@ -43,7 +43,7 @@ typedef struct blackboxConfig_s {
     uint8_t     mode;
     uint16_t    denom;
     uint32_t    fields;
-    uint32_t    initialEraseFreeSpace;
+    uint16_t    initialEraseFreeSpaceKiB;
 } blackboxConfig_t;
 
 PG_DECLARE(blackboxConfig_t, blackboxConfig);

--- a/src/main/target/STM32_UNIFIED/target.h
+++ b/src/main/target/STM32_UNIFIED/target.h
@@ -365,6 +365,7 @@
 #define USE_SDCARD_SPI
 
 #define USE_FLASHFS
+#define USE_FLASHFS_LOOP
 #define USE_FLASH_TOOLS
 #define USE_FLASH_M25P16
 #define USE_FLASH_W25N01G          // 1Gb NAND flash support

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -491,6 +491,15 @@ sbus_output_unittest_DEFINES := \
 emfat_unittest_SRC := \
 		$(USER_DIR)/msc/emfat.c
 
+flashfs_unittest_SRC := \
+		$(USER_DIR)/io/flashfs.c \
+		$(USER_DIR)/pg/blackbox.c \
+		$(TEST_DIR)/flashfs_unittest.include/flash_emulator.cc \
+		$(TEST_DIR)/flashfs_unittest.include/flash_c_stub.cc
+
+flashfs_unittest_DEFINES := \
+		USE_FLASHFS_LOOP
+
 # Please tweak the following variable definitions as needed by your
 # project, except GTEST_HEADERS, which you can use in your own targets
 # but shouldn't modify.
@@ -562,7 +571,7 @@ $(info CC version: $(shell $(CC) --version))
 $(info CXX version: $(shell $(CXX) --version))
 
 USE_PTHREAD = YES
-USE_COVERAGE = YES
+USE_COVERAGE =
 ifeq ($(OSFAMILY), macosx)
 	USE_PTHREAD =
 endif
@@ -619,7 +628,7 @@ GTEST_HEADERS = $(GTEST_DIR)/include/gtest/*.h \
 
 # All Google Mock headers. Note that all Google Test headers are
 # included here too, as they are #included by Google Mock headers.
-# Usually you shouldn't change this definition.	
+# Usually you shouldn't change this definition.
 GMOCK_HEADERS = $(GMOCK_DIR)/include/gmock/*.h \
                 $(GMOCK_DIR)/include/gmock/internal/*.h \
                 $(GTEST_HEADERS)
@@ -787,6 +796,14 @@ $(OBJECT_DIR)/$1/%.c.o: $(TEST_DIR)/%.c
 	$(V1) $(CC) $(C_FLAGS) $$(call test_cflags,$$($1_INCLUDE_DIRS)) \
                 $$(foreach def,$$($1_DEFINES),-D $$(def)) \
                 -c $$< -o $$@
+
+$(OBJECT_DIR)/$1/%.cc.o: $(TEST_DIR)/%.cc
+	@echo "compiling test c file: $$<" "$(STDOUT)"
+	$(V1) mkdir -p $$(dir $$@)
+	$(V1) $(CXX) $(CXX_FLAGS) $$(call test_cflags,$$($1_INCLUDE_DIRS)) \
+                $$(foreach def,$$($1_DEFINES),-D $$(def)) \
+                -c $$< -o $$@
+
 
 ifneq ($1,$(basename $1))
 # per-target tests may compile files from the target directory

--- a/src/test/unit/flashfs_unittest.cc
+++ b/src/test/unit/flashfs_unittest.cc
@@ -115,6 +115,8 @@ TEST_F(FlashFSTestBase, flashfsWrite)
 TEST_F(FlashFSTestBase, flashfsWriteOverFlashSize)
 {
     flashfsInit();
+    blackboxConfigMutable()->rollingErase = false;
+
     // Unexpectedly, the flashfs can't handle EOF if writes are not aligned to
     // BLOCK_SIZE (2048) Let's just ignore this bug.
     // constexpr uint32_t kBufferSize = FLASHFS_WRITE_BUFFER_USABLE - 10;
@@ -209,6 +211,9 @@ TEST_F(FlashFSLoopTest, StartFromZero)
     flashfsInit();
     EXPECT_EQ(headAddress, 0);
     EXPECT_EQ(tailAddress, sector_size_ + page_size_);
+    EXPECT_TRUE(flash_emulator_->IsErased(tailAddress, sector_size_));
+
+    EXPECT_FALSE(flashfsIsEOF());
 }
 
 TEST_F(FlashFSLoopTest, Flat)
@@ -222,6 +227,9 @@ TEST_F(FlashFSLoopTest, Flat)
     flashfsInit();
     EXPECT_EQ(headAddress, sector_size_);
     EXPECT_EQ(tailAddress, 2 * sector_size_ + page_size_);
+    EXPECT_TRUE(flash_emulator_->IsErased(tailAddress, sector_size_));
+
+    EXPECT_FALSE(flashfsIsEOF());
 }
 
 TEST_F(FlashFSLoopTest, Wrapped1)
@@ -240,6 +248,7 @@ TEST_F(FlashFSLoopTest, Wrapped1)
     flashfsInit();
     EXPECT_EQ(headAddress, kStartOfLastSector);
     EXPECT_EQ(tailAddress, page_size_);
+    EXPECT_TRUE(flash_emulator_->IsErased(tailAddress, sector_size_));
 }
 
 TEST_F(FlashFSLoopTest, Wrapped2)
@@ -253,6 +262,7 @@ TEST_F(FlashFSLoopTest, Wrapped2)
     flashfsInit();
     EXPECT_EQ(headAddress, sector_size_);
     EXPECT_EQ(tailAddress, 0);
+    EXPECT_TRUE(flash_emulator_->IsErased(tailAddress, sector_size_));
 }
 
 TEST_F(FlashFSLoopTest, Wrapped3)
@@ -264,7 +274,7 @@ TEST_F(FlashFSLoopTest, Wrapped3)
         kBoundarySector * sector_size_ - page_size_;
     const uint32_t kEmptyStop = kBoundarySector * sector_size_;
 
-    // Fill all sectors except [kEmptyStart, kEmptyStop). The size = 1 page.
+    // Fill all sectors except [kEmptyStart, kEmptyStop). The unfilled size = 1 page.
     flash_emulator_->Fill(flash_emulator_->kFlashFSStart, 0x55,
                           kEmptyStart - flash_emulator_->kFlashFSStart);
     flash_emulator_->Fill(kEmptyStop, 0x55,
@@ -273,6 +283,7 @@ TEST_F(FlashFSLoopTest, Wrapped3)
     flashfsInit();
     EXPECT_EQ(headAddress, kEmptyStop);
     EXPECT_EQ(tailAddress, kEmptyStart);
+    EXPECT_TRUE(flash_emulator_->IsErased(tailAddress, page_size_));
 }
 
 TEST_F(FlashFSLoopTest, Full)
@@ -371,7 +382,18 @@ TEST_F(FlashFSLoopTest, WrappedRead)
     }
 }
 
-class FlashFSLoopInitialEraseTest : public FlashFSTestBase {};
+class FlashFSLoopInitialEraseTest : public FlashFSTestBase {
+    // In this test, flashfsEraseAsync() has to run in the background.
+    void SetUp() override {
+        FlashFSTestBase::SetUp();
+    }
+    void TearDown() override {
+        while(!flashfsIsReady()) {
+            flashfsEraseAsync();
+}
+        FlashFSTestBase::TearDown();
+    }
+};
 
 TEST_F(FlashFSLoopInitialEraseTest, Normal)
 {
@@ -396,9 +418,9 @@ TEST_F(FlashFSLoopInitialEraseTest, Normal)
 
     blackboxConfigMutable()->initialEraseFreeSpaceKiB = initial_erase_kb;
     flashfsLoopInitialErase();
-    while (!flashfsIsReady()) {
+
+    while (!flashfsIsReady())
         flashfsEraseAsync();
-    }
 
     EXPECT_EQ(headAddress, kEmptyStop + initial_erase_kb * 1024);
     EXPECT_TRUE(flash_emulator_->IsErased(kEmptyStop, initial_erase_kb * 1024));
@@ -419,6 +441,7 @@ TEST_F(FlashFSLoopInitialEraseTest, Wrapped)
                           flash_emulator_->kFlashFSEnd - kEmptyStop);
 
     flashfsInit();
+    EXPECT_TRUE(flashfsIsReady());
     EXPECT_EQ(headAddress, kEmptyStop);
     EXPECT_EQ(tailAddress, kEmptyStart);
 
@@ -430,9 +453,8 @@ TEST_F(FlashFSLoopInitialEraseTest, Wrapped)
 
     blackboxConfigMutable()->initialEraseFreeSpaceKiB = initial_erase_kb;
     flashfsLoopInitialErase();
-    while (!flashfsIsReady()) {
+    while (!flashfsIsReady())
         flashfsEraseAsync();
-    }
 
     // wrapped kEmptyStop + sector_size_ * 2
     EXPECT_EQ(headAddress, sector_size_);
@@ -499,4 +521,51 @@ TEST(InitialErase, U16KiBOverflow)
     }
 
     EXPECT_TRUE(flash_emulator->IsErased(0, 64 * 1024 * 1024));
+}
+
+
+class FlashFSLoopRollingEraseTest : public FlashFSLoopInitialEraseTest { };
+
+TEST_F(FlashFSLoopRollingEraseTest, flashfsWriteOverFlashSize)
+{
+    flashfsInit();
+    EXPECT_TRUE(flashfsIsReady());
+    blackboxConfigMutable()->rollingErase = true;
+
+    constexpr uint32_t kBufferSize = 128;
+    constexpr uint8_t kByte = 0x44;
+    auto buffer = std::make_unique<uint8_t[]>(kBufferSize);
+    memset(buffer.get(), kByte, kBufferSize);
+
+    EXPECT_EQ(headAddress, 0);
+    EXPECT_EQ(tailAddress, 0);
+
+    uint32_t written = 0;
+    do {
+        flashfsWrite(buffer.get(), kBufferSize);
+        flashfsFlushSync();
+        written += kBufferSize;
+        flashfsEraseAsync();
+    } while (written <= flash_emulator_->kFlashFSSize * 2);
+
+    // This test is non-deterministic.
+    // After writing the full flashfs space once, it will start background erasing,
+    // where a lot of writes can be silently dropped (we are writing way faster
+    // than the actual BBlog). In the end, we check if there's less than 2
+    // erased sector and call it success.
+    uint32_t erased = 0;
+    uint32_t current = -1;
+    for (uint32_t i = 0; i < flash_emulator_->kFlashFSSize; i++) {
+        ASSERT_TRUE(flash_emulator_->memory_[i] == kByte ||
+                    flash_emulator_->memory_[i] == 0xff)
+            << "Mismatch address " << std::hex << i;
+        if (current!=flash_emulator_->memory_[i]) {
+            current = flash_emulator_->memory_[i];
+            std::cout << "offset " << std::hex << i << " = " << current << std::endl;
+        }
+        if (flash_emulator_->memory_[i] == 0xff) {
+            erased++;
+        }
+    }
+    EXPECT_LE(erased, sector_size_ * 2);
 }

--- a/src/test/unit/flashfs_unittest.cc
+++ b/src/test/unit/flashfs_unittest.cc
@@ -397,7 +397,7 @@ class FlashFSLoopInitialEraseTest : public FlashFSTestBase {
 
 TEST_F(FlashFSLoopInitialEraseTest, Normal)
 {
-    // Arming erase happens in the contiguous area.
+    // Initial erase happens in the contiguous area.
     const uint16_t kBoundarySector = 4;
     const uint32_t kEmptyStart =
         kBoundarySector * sector_size_ - page_size_;
@@ -428,7 +428,7 @@ TEST_F(FlashFSLoopInitialEraseTest, Normal)
 
 TEST_F(FlashFSLoopInitialEraseTest, Wrapped)
 {
-    // Arming erase happens in the wrap boundary -- the last sector and the
+    // Initial erase happens in the wrap boundary -- the last sector and the
     // first sector.
     const uint16_t kBoundarySector = flash_emulator_->kFlashFSSizeInSectors - 1;
     const uint32_t kEmptyStart = kBoundarySector * sector_size_ - page_size_;
@@ -549,7 +549,7 @@ TEST_F(FlashFSLoopRollingEraseTest, flashfsWriteOverFlashSize)
     } while (written <= flash_emulator_->kFlashFSSize * 2);
 
     // This test is non-deterministic.
-    // After writing the full flashfs space once, it will start background erasing,
+    // After writing the full flashfs space once, it will start rolling erasing,
     // where a lot of writes can be silently dropped (we are writing way faster
     // than the actual BBlog). In the end, we check if there's less than 2
     // erased sector and call it success.

--- a/src/test/unit/flashfs_unittest.cc
+++ b/src/test/unit/flashfs_unittest.cc
@@ -1,0 +1,462 @@
+/*
+ * This file is part of Rotorflight.
+ *
+ * Rotorflight is free software. You can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Rotorflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include <limits.h>
+
+extern "C" {
+#include "io/flashfs.h"
+#include "pg/blackbox.h"
+
+extern uint32_t flashfsSize;
+extern uint32_t headAddress;
+extern uint32_t tailAddress;
+}
+
+#include "flashfs_unittest.include/flash_c_stub.h"
+#include "flashfs_unittest.include/flash_emulator.h"
+#include "flashfs_unittest.include/flash_mock.h"
+
+#include "unittest_macros.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+/*
+ * There are some weird logic behind flashfs.c and flash.c. This unittest is
+ * written to accomedate them
+ *   * flashfs (and some other places) assumes the "flashfs" partition starts
+ *     from sector 0. This is made true by the partition allocator.
+ *   * flashfs can't handle EOF gracefully if writes are not aligned to
+ *     BLOCK_SIZE (e.g., flashfs will attempt to write over EOF).
+ *   * ProgramBegin() ProgramContinue() ProgramFinish() aren't page-align
+ *     checked.
+ *
+ */
+
+void pgReset(void) {
+    // We will use the real config variable
+    extern blackboxConfig_t pgResetTemplate_blackboxConfig;
+    memcpy(blackboxConfigMutable(), &pgResetTemplate_blackboxConfig,
+           sizeof(blackboxConfig_t));
+}
+
+class FlashFSTestBase : public ::testing::Test {
+  public:
+    void SetUp() override
+    {
+        pgReset();
+        flash_emulator_ = std::make_shared<FlashEmulator>();
+        g_flash_stub = flash_emulator_;
+        page_size_ = flash_emulator_->kPageSize;
+        sector_size_ = flash_emulator_->kSectorSize;
+        flashfs_size_ = flash_emulator_->kFlashFSSize;
+    }
+
+    uint16_t page_size_;
+    uint16_t sector_size_;
+    uint32_t flashfs_size_;
+    std::shared_ptr<FlashEmulator> flash_emulator_;
+};
+
+TEST_F(FlashFSTestBase, flashfsInit)
+{
+    flashfsInit();
+    EXPECT_EQ(flashfsSize, flashfs_size_);
+}
+
+TEST_F(FlashFSTestBase, flashfsIdentifyStartOfFreeSpace)
+{
+    flashfsInit();
+
+    constexpr uint32_t kExpectedWritepoint = 16 * 1024;
+    constexpr uint32_t kFillSize = kExpectedWritepoint - 60;
+    flash_emulator_->Fill(0, 0x55, kFillSize);
+
+    uint32_t writepoint = flashfsIdentifyStartOfFreeSpace();
+    EXPECT_EQ(writepoint, kExpectedWritepoint);
+}
+
+TEST_F(FlashFSTestBase, flashfsWrite)
+{
+    constexpr uint32_t kExpectedWritepoint1 = 16 * 1024;
+    constexpr uint8_t kByte1 = 0x33;
+    // Pre-fill some data
+    constexpr uint32_t kFillSize = kExpectedWritepoint1 - 60;
+    flash_emulator_->Fill(0, 0x55, kFillSize);
+
+    flashfsInit();
+    EXPECT_EQ(tailAddress, kExpectedWritepoint1);
+    flashfsWriteByte(0x33);
+    flashfsFlushSync();
+    flashfsClose();
+    EXPECT_EQ(flash_emulator_->memory_[kExpectedWritepoint1], kByte1);
+
+    const uint32_t kExpectedWritepoint2 = kExpectedWritepoint1 + page_size_;
+    flashfsInit();
+    EXPECT_EQ(tailAddress, kExpectedWritepoint2);
+}
+
+TEST_F(FlashFSTestBase, flashfsWriteOverFlashSize)
+{
+    flashfsInit();
+    // Unexpectedly, the flashfs can't handle EOF if writes are not aligned to
+    // BLOCK_SIZE (2048) Let's just ignore this bug.
+    // constexpr uint32_t kBufferSize = FLASHFS_WRITE_BUFFER_USABLE - 10;
+    constexpr uint32_t kBufferSize = 128;
+    constexpr uint8_t kByte = 0x44;
+    auto buffer = std::make_unique<uint8_t[]>(kBufferSize);
+    memset(buffer.get(), kByte, kBufferSize);
+
+    EXPECT_EQ(tailAddress, 0);
+
+    uint32_t written = 0;
+    do {
+        flashfsWrite(buffer.get(), kBufferSize);
+        flashfsFlushSync();
+        written += kBufferSize;
+    } while (written <= flash_emulator_->kFlashFSSize + 5000);
+
+    // If LOOP_FLASHFS is enabled, we don't write the last page + maybe flashfs
+    // write buffer size.
+    for (uint32_t i = 0; i < flash_emulator_->kFlashFSSize - page_size_ -
+                                 FLASHFS_WRITE_BUFFER_SIZE;
+         i++) {
+        ASSERT_EQ(flash_emulator_->memory_[i], kByte)
+            << "Mismatch address " << std::hex << i;
+    }
+}
+
+class FlashFSBandwidthTest
+    : public FlashFSTestBase,
+      public testing::WithParamInterface<FlashEmulator::FlashType> {
+  public:
+    void SetUp() override
+    {
+        pgReset();
+        // Create 64KiB flash emulator
+        flash_emulator_ =
+            std::make_shared<FlashEmulator>(GetParam(), 2048, 4, 8, 0, 8);
+        g_flash_stub = flash_emulator_;
+        flashfsInit();
+    };
+};
+
+TEST_P(FlashFSBandwidthTest, WriteBandwidth)
+{
+    constexpr uint32_t kBufferSize = 128;
+    constexpr uint8_t kByte = 0x44;
+    auto buffer = std::make_unique<uint8_t[]>(kBufferSize);
+    memset(buffer.get(), kByte, kBufferSize);
+
+    EXPECT_EQ(tailAddress, 0);
+
+    auto start = std::chrono::system_clock::now();
+
+    uint32_t written = 0;
+    do {
+        flashfsWrite(buffer.get(), kBufferSize);
+        flashfsFlushSync();
+        written += kBufferSize;
+    } while (written < flash_emulator_->kFlashFSSize);
+
+    auto end = std::chrono::system_clock::now();
+    std::chrono::duration<double> elapsed_seconds = end - start;
+    std::cout << "Write Bandwidth = " << 64 / elapsed_seconds.count()
+              << " KiB/s." << std::endl;
+    std::cout << "This is just an estimate based on the worst case from spec."
+              << std::endl;
+}
+
+INSTANTIATE_TEST_SUITE_P(DISABLED_AllFlashTypes, FlashFSBandwidthTest,
+                         testing::Values(FlashEmulator::kFlashW25N01G,
+                                         FlashEmulator::kFlashW25Q128FV,
+                                         FlashEmulator::kFlashM25P16));
+
+class FlashFSLoopTest : public FlashFSTestBase {};
+
+TEST_F(FlashFSLoopTest, StartFromZero)
+{
+    // Test when data starts from 0.
+    flashfsInit();
+    EXPECT_EQ(headAddress, 0);
+    EXPECT_EQ(tailAddress, 0);
+
+    // Fill begining of sector 0
+    flash_emulator_->Fill(0, 0x55, 5);
+    flashfsInit();
+    EXPECT_EQ(headAddress, 0);
+    EXPECT_EQ(tailAddress, page_size_);
+
+    // Fill sector 0 and begining of sector 1
+    flash_emulator_->FillSector(flash_emulator_->kFlashFSStartSector, 0x55, 1);
+    flash_emulator_->Fill(sector_size_, 0x55, 5);
+    flashfsInit();
+    EXPECT_EQ(headAddress, 0);
+    EXPECT_EQ(tailAddress, sector_size_ + page_size_);
+}
+
+TEST_F(FlashFSLoopTest, Flat)
+{
+    // Test when data stripe is not wrapped.
+    // Fill sector 1 and 2.
+    flash_emulator_->Fill(1 * sector_size_, 0x55,
+                          sector_size_);
+    flash_emulator_->Fill(2 * sector_size_, 0x55, 5);
+
+    flashfsInit();
+    EXPECT_EQ(headAddress, sector_size_);
+    EXPECT_EQ(tailAddress, 2 * sector_size_ + page_size_);
+}
+
+TEST_F(FlashFSLoopTest, Wrapped1)
+{
+    // Test when data region is wrapped.
+    // Fill sector -1 and partially 0.
+    const uint32_t kStartOfLastSector =
+        (flash_emulator_->kFlashFSStartSector +
+         flash_emulator_->kFlashFSSizeInSectors - 1) *
+        sector_size_;
+
+    flash_emulator_->Fill(0, 0x55, 5);
+    flash_emulator_->Fill(kStartOfLastSector, 0x55,
+                          sector_size_);
+
+    flashfsInit();
+    EXPECT_EQ(headAddress, kStartOfLastSector);
+    EXPECT_EQ(tailAddress, page_size_);
+}
+
+TEST_F(FlashFSLoopTest, Wrapped2)
+{
+    // Test when data region is wrapped.
+    // Fill all sectors except 0.
+    flash_emulator_->Fill(sector_size_, 0x55,
+                          flash_emulator_->kFlashFSSize -
+                              sector_size_);
+
+    flashfsInit();
+    EXPECT_EQ(headAddress, sector_size_);
+    EXPECT_EQ(tailAddress, 0);
+}
+
+TEST_F(FlashFSLoopTest, Wrapped3)
+{
+    // Test when data region is wrapped.
+
+    const uint16_t kBoundarySector = 4;
+    const uint32_t kEmptyStart =
+        kBoundarySector * sector_size_ - page_size_;
+    const uint32_t kEmptyStop = kBoundarySector * sector_size_;
+
+    // Fill all sectors except [kEmptyStart, kEmptyStop). The size = 1 page.
+    flash_emulator_->Fill(flash_emulator_->kFlashFSStart, 0x55,
+                          kEmptyStart - flash_emulator_->kFlashFSStart);
+    flash_emulator_->Fill(kEmptyStop, 0x55,
+                          flash_emulator_->kFlashFSEnd - kEmptyStop);
+
+    flashfsInit();
+    EXPECT_EQ(headAddress, kEmptyStop);
+    EXPECT_EQ(tailAddress, kEmptyStart);
+}
+
+TEST_F(FlashFSLoopTest, Full)
+{
+    // Test when flash is fully written
+    flash_emulator_->Fill(0, 0x55, flash_emulator_->kFlashFSSize);
+
+    flashfsInit();
+    EXPECT_EQ(headAddress, 0);
+    EXPECT_EQ(tailAddress, flash_emulator_->kFlashFSSize - page_size_);
+    EXPECT_TRUE(flashfsIsEOF());
+
+    // Fill all sectors except [0, page_size_), this is abnormal
+    // and is also considered full.
+    flash_emulator_->Fill(page_size_, 0x55,
+                          flash_emulator_->kFlashFSSize - page_size_);
+
+    flashfsInit();
+    EXPECT_EQ(headAddress, 0);
+    EXPECT_EQ(tailAddress, flash_emulator_->kFlashFSSize - page_size_);
+    EXPECT_TRUE(flashfsIsEOF());
+}
+
+TEST_F(FlashFSLoopTest, WriteTest)
+{
+    // Test a wrapped write
+    // We will start writing from the last (physical) sector.
+    const uint32_t kFillStart = flashfs_size_ - sector_size_;
+
+    flash_emulator_->Fill(kFillStart, 0x44, page_size_);
+    flashfsInit();
+
+    EXPECT_EQ(headAddress, kFillStart);
+    EXPECT_EQ(tailAddress, kFillStart + page_size_);
+
+    // Now let's write one sector, we should end at sector 0 page 0
+    constexpr uint32_t kBufferSize = 128;
+    auto buffer = std::make_unique<uint8_t[]>(kBufferSize);
+    memset(buffer.get(), 0x55, kBufferSize);
+
+    uint32_t written = 0;
+    do {
+        flashfsWrite(buffer.get(), kBufferSize);
+        flashfsFlushSync();
+        written += kBufferSize;
+    } while (written < sector_size_);
+
+    EXPECT_EQ(tailAddress, page_size_);
+
+    // [kFillStart, kFillStart + page_size_) should contain original 0x44
+    for (uint32_t i = kFillStart; i < kFillStart + page_size_; i++) {
+        ASSERT_EQ(flash_emulator_->memory_[i], 0x44)
+            << "Mismatch address " << std::hex << i;
+    }
+
+    // [kFillStart + page_size_, FlashFSEnd) should contain 0x55
+    for (uint32_t i = kFillStart + page_size_; i < flashfs_size_; i++) {
+        ASSERT_EQ(flash_emulator_->memory_[i], 0x55)
+            << "Mismatch address " << std::hex << i;
+    }
+
+    // [0, page_size) should also contain 0x55
+    for (uint32_t i = 0; i < page_size_; i++) {
+        ASSERT_EQ(flash_emulator_->memory_[i], 0x55)
+            << "Mismatch address " << std::hex << i;
+    }
+}
+
+TEST_F(FlashFSLoopTest, WrappedRead)
+{
+    const uint16_t kBoundarySector = 4;
+    const uint32_t kEmptyStart =
+        kBoundarySector * sector_size_ - page_size_;
+    const uint32_t kEmptyStop = kBoundarySector * sector_size_;
+
+    // Fill all sectors except [kEmptyStart, kEmptyStop). The unfilled size = 1 page.
+    flash_emulator_->Fill(flash_emulator_->kFlashFSStart, 0x55,
+                          kEmptyStart - flash_emulator_->kFlashFSStart);
+    flash_emulator_->Fill(kEmptyStop, 0x55,
+                          flash_emulator_->kFlashFSEnd - kEmptyStop);
+    flashfsInit();
+    EXPECT_EQ(headAddress, kEmptyStop);
+    EXPECT_EQ(tailAddress, kEmptyStart);
+    // Read from -page_size and read 2* page_size.
+    const uint32_t kPhysicalAddress = flash_emulator_->kFlashFSEnd - page_size_;
+    const uint32_t kLogicalAddress = kPhysicalAddress - headAddress;
+    const uint32_t kSize = 2 * page_size_;
+    std::unique_ptr<uint8_t[]> buffer = std::make_unique<uint8_t[]>(kSize);
+    EXPECT_GT(kPhysicalAddress, headAddress);
+    EXPECT_GT(kPhysicalAddress, tailAddress);
+    EXPECT_GT(headAddress, tailAddress);
+    flashfsReadAbs(kLogicalAddress, buffer.get(), kSize);
+    for (uint32_t i = 0; i < page_size_; i++) {
+        ASSERT_EQ(buffer[i], 0x55)
+            << "Read mismatch. Address " << std::hex << i;
+    }
+}
+
+class FlashFSLoopInitialEraseTest : public FlashFSTestBase {};
+
+TEST_F(FlashFSLoopInitialEraseTest, Normal)
+{
+    // Arming erase happens in the contiguous area.
+    const uint16_t kBoundarySector = 4;
+    const uint32_t kEmptyStart =
+        kBoundarySector * sector_size_ - page_size_;
+    const uint32_t kEmptyStop = kBoundarySector * sector_size_;
+
+    // Fill all sectors except [kEmptyStart, kEmptyStop). The size = 1 page.
+    flash_emulator_->Fill(flash_emulator_->kFlashFSStart, 0x55,
+                          kEmptyStart - flash_emulator_->kFlashFSStart);
+    flash_emulator_->Fill(kEmptyStop, 0x55,
+                          flash_emulator_->kFlashFSEnd - kEmptyStop);
+
+    flashfsInit();
+    EXPECT_EQ(headAddress, kEmptyStop);
+    EXPECT_EQ(tailAddress, kEmptyStart);
+
+    // Now let's try to auto erase
+    blackboxConfigMutable()->initialEraseFreeSpace = sector_size_ * 2;
+    flashfsLoopInitialErase();
+    while(!flashfsIsReady()) {
+        flashfsEraseAsync();
+    }
+
+    EXPECT_EQ(headAddress, kEmptyStop + sector_size_ * 2);
+    EXPECT_TRUE(flash_emulator_->IsErased(kEmptyStop, sector_size_ * 2));
+}
+
+TEST_F(FlashFSLoopInitialEraseTest, Wrapped)
+{
+    // Arming erase happens in the wrap boundary -- the last sector and the
+    // first sector.
+    const uint16_t kBoundarySector = flash_emulator_->kFlashFSSizeInSectors - 1;
+    const uint32_t kEmptyStart = kBoundarySector * sector_size_ - page_size_;
+    const uint32_t kEmptyStop = kBoundarySector * sector_size_;
+
+    // Fill all sectors except [kEmptyStart, kEmptyStop). The size = 1 page.
+    flash_emulator_->Fill(flash_emulator_->kFlashFSStart, 0x55,
+                          kEmptyStart - flash_emulator_->kFlashFSStart);
+    flash_emulator_->Fill(kEmptyStop, 0x55,
+                          flash_emulator_->kFlashFSEnd - kEmptyStop);
+
+    flashfsInit();
+    EXPECT_EQ(headAddress, kEmptyStop);
+    EXPECT_EQ(tailAddress, kEmptyStart);
+
+    // Now let's try to auto erase
+    blackboxConfigMutable()->initialEraseFreeSpace = sector_size_ * 2;
+    flashfsLoopInitialErase();
+    while(!flashfsIsReady()) {
+        flashfsEraseAsync();
+    }
+
+    // wrapped kEmptyStop + sector_size_ * 2
+    EXPECT_EQ(headAddress, sector_size_);
+    EXPECT_TRUE(flash_emulator_->IsErased(kEmptyStop, sector_size_));
+    EXPECT_TRUE(flash_emulator_->IsErased(0, sector_size_));
+}
+
+TEST_F(FlashFSLoopInitialEraseTest, UnalignedSize)
+{
+    const uint16_t kBoundarySector = 4;
+    const uint32_t kEmptyStart =
+        kBoundarySector * sector_size_ - page_size_;
+    const uint32_t kEmptyStop = kBoundarySector * sector_size_;
+
+    // Fill all sectors except [kEmptyStart, kEmptyStop). The size = 1 page.
+    flash_emulator_->Fill(flash_emulator_->kFlashFSStart, 0x55,
+                          kEmptyStart - flash_emulator_->kFlashFSStart);
+    flash_emulator_->Fill(kEmptyStop, 0x55,
+                          flash_emulator_->kFlashFSEnd - kEmptyStop);
+
+    flashfsInit();
+    EXPECT_EQ(headAddress, kEmptyStop);
+    EXPECT_EQ(tailAddress, kEmptyStart);
+
+    // Now let's try to auto erase
+    blackboxConfigMutable()->initialEraseFreeSpace = sector_size_ - 1;
+    flashfsLoopInitialErase();
+    while(!flashfsIsReady()) {
+        flashfsEraseAsync();
+    }
+
+    EXPECT_EQ(headAddress, kEmptyStop + sector_size_);
+    EXPECT_TRUE(flash_emulator_->IsErased(kEmptyStop, sector_size_));
+}

--- a/src/test/unit/flashfs_unittest.include/flash_c_stub.cc
+++ b/src/test/unit/flashfs_unittest.include/flash_c_stub.cc
@@ -1,0 +1,114 @@
+/*
+ * This file is part of Rotorflight.
+ *
+ * Rotorflight is free software. You can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Rotorflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/*
+ * This file is to be linked with module under test. It provides all c function
+ * stubs of flash.c and call the corresponding member methods defined in
+ * FlashInterface, which is virtual and can be gmock or fake implementation.
+ */
+
+extern "C" {
+#include "drivers/flash.h"
+}
+
+#include "flash_interface.h"
+#include "pg/flash.h"
+
+#include <memory>
+
+#include "gmock/gmock.h"
+
+std::weak_ptr<FlashInterface> g_flash_stub;
+
+void flashPreInit(const flashConfig_t *flashConfig) {
+    auto flash_intf = g_flash_stub.lock();
+    flash_intf->flashPreInit(flashConfig);
+}
+bool flashInit(const flashConfig_t *flashConfig) {
+    auto flash_intf = g_flash_stub.lock();
+    return flash_intf->flashInit(flashConfig);
+}
+
+bool flashIsReady(void) {
+    auto flash_intf = g_flash_stub.lock();
+    return flash_intf->flashIsReady();
+}
+bool flashWaitForReady(void) {
+    auto flash_intf = g_flash_stub.lock();
+    return flash_intf->flashWaitForReady();
+}
+void flashEraseSector(uint32_t address) {
+    auto flash_intf = g_flash_stub.lock();
+    flash_intf->flashEraseSector(address);
+}
+void flashEraseCompletely(void) {
+    auto flash_intf = g_flash_stub.lock();
+    flash_intf->flashEraseCompletely();
+}
+void flashPageProgramBegin(uint32_t address, void (*callback)(uint32_t arg)) {
+    auto flash_intf = g_flash_stub.lock();
+    flash_intf->flashPageProgramBegin(address, callback);
+}
+uint32_t flashPageProgramContinue(const uint8_t **buffers,
+                                  uint32_t *bufferSizes, uint32_t bufferCount) {
+    auto flash_intf = g_flash_stub.lock();
+    return flash_intf->flashPageProgramContinue(buffers, bufferSizes,
+                                                bufferCount);
+}
+void flashPageProgramFinish(void) {
+    auto flash_intf = g_flash_stub.lock();
+    flash_intf->flashPageProgramFinish();
+}
+void flashPageProgram(uint32_t address, const uint8_t *data, uint32_t length,
+                      void (*callback)(uint32_t length)) {
+    auto flash_intf = g_flash_stub.lock();
+    flash_intf->flashPageProgram(address, data, length, callback);
+}
+int flashReadBytes(uint32_t address, uint8_t *buffer, uint32_t length) {
+    auto flash_intf = g_flash_stub.lock();
+    return flash_intf->flashReadBytes(address, buffer, length);
+}
+void flashFlush(void) {
+    auto flash_intf = g_flash_stub.lock();
+    flash_intf->flashFlush();
+}
+const flashGeometry_t *flashGetGeometry(void) {
+    auto flash_intf = g_flash_stub.lock();
+    return flash_intf->flashGetGeometry();
+}
+
+void flashPartitionSet(uint8_t index, uint32_t startSector,
+                       uint32_t endSector) {
+    auto flash_intf = g_flash_stub.lock();
+    flash_intf->flashPartitionSet(index, startSector, endSector);
+}
+flashPartition_t *flashPartitionFindByType(flashPartitionType_e type) {
+    auto flash_intf = g_flash_stub.lock();
+    return flash_intf->flashPartitionFindByType(type);
+}
+const flashPartition_t *flashPartitionFindByIndex(uint8_t index) {
+    auto flash_intf = g_flash_stub.lock();
+    return flash_intf->flashPartitionFindByIndex(index);
+}
+const char *flashPartitionGetTypeName(flashPartitionType_e type) {
+    auto flash_intf = g_flash_stub.lock();
+    return flash_intf->flashPartitionGetTypeName(type);
+}
+int flashPartitionCount(void) {
+    auto flash_intf = g_flash_stub.lock();
+    return flash_intf->flashPartitionCount();
+}

--- a/src/test/unit/flashfs_unittest.include/flash_c_stub.h
+++ b/src/test/unit/flashfs_unittest.include/flash_c_stub.h
@@ -15,35 +15,7 @@
  * along with this software. If not, see <https://www.gnu.org/licenses/>.
  */
 
-#pragma once
+#include "flash_interface.h"
+#include <memory>
 
-#include "types.h"
-#include "platform.h"
-
-#include "pg/pg.h"
-
-
-typedef enum {
-    BLACKBOX_DEVICE_NONE = 0,
-    BLACKBOX_DEVICE_FLASH = 1,
-    BLACKBOX_DEVICE_SDCARD = 2,
-    BLACKBOX_DEVICE_SERIAL = 3
-} BlackboxDevice_e;
-
-typedef enum {
-    BLACKBOX_MODE_OFF = 0,
-    BLACKBOX_MODE_NORMAL,
-    BLACKBOX_MODE_ARMED,
-    BLACKBOX_MODE_SWITCH,
-} BlackboxMode_e;
-
-
-typedef struct blackboxConfig_s {
-    uint8_t     device;
-    uint8_t     mode;
-    uint16_t    denom;
-    uint32_t    fields;
-    uint32_t    initialEraseFreeSpace;
-} blackboxConfig_t;
-
-PG_DECLARE(blackboxConfig_t, blackboxConfig);
+extern std::weak_ptr<FlashInterface> g_flash_stub;

--- a/src/test/unit/flashfs_unittest.include/flash_emulator.cc
+++ b/src/test/unit/flashfs_unittest.include/flash_emulator.cc
@@ -115,9 +115,7 @@ uint32_t FlashEmulator::flashPageProgramContinue(const uint8_t **buffers,
             written++;
         }
     }
-    if (write_buffer_tail_ == kPageSize) {
-        Program();
-    }
+
     //    printf("ProgramContinue: written[0x%x]", written);
     return written;
 }

--- a/src/test/unit/flashfs_unittest.include/flash_emulator.cc
+++ b/src/test/unit/flashfs_unittest.include/flash_emulator.cc
@@ -1,0 +1,243 @@
+/*
+ * This file is part of Rotorflight.
+ *
+ * Rotorflight is free software. You can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Rotorflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include <cassert>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <thread>
+
+#include "drivers/flash.h"
+#include "pg/flash.h"
+
+#include "flash_emulator.h"
+
+void FlashEmulator::flashPreInit(const flashConfig_t *flashConfig) {
+    UNUSED(flashConfig);
+}
+bool FlashEmulator::flashInit(const flashConfig_t *flashConfig) {
+    UNUSED(flashConfig);
+    return true;
+}
+bool FlashEmulator::flashIsReady(void) {
+    return flash_state_ == kFlashStateIdle;
+}
+bool FlashEmulator::flashWaitForReady(void) {
+    while (flash_state_ != kFlashStateIdle)
+        ;
+    return true;
+}
+void FlashEmulator::flashEraseSector(uint32_t address) {
+    // Both w25n01g driver and w25q128fv driver wait for idle here.
+    // The logic behind m25p16 driver is unclear.
+    flashWaitForReady();
+    assert(flash_state_ == kFlashStateIdle);
+    flash_state_ = kFlashStateErasing;
+    std::thread erase_thread([&, address]() {
+        // Wait for erase time
+        switch (kFlashType) {
+        case kFlashW25N01G:
+            std::this_thread::sleep_for(std::chrono::milliseconds(10));
+            break;
+        case kFlashW25Q128FV:
+            std::this_thread::sleep_for(std::chrono::milliseconds(400));
+            break;
+        case kFlashM25P16:
+            std::this_thread::sleep_for(std::chrono::seconds(3));
+            break;
+        case kFlashRAM:
+            break;
+        }
+        uint32_t sector = GetSectorIndex(address);
+        uint32_t base_address = sector * kSectorSize;
+        memset(&memory_[base_address], 0xff, kSectorSize);
+        flash_state_ = kFlashStateIdle;
+    });
+    erase_thread.detach();
+};
+void FlashEmulator::flashEraseCompletely(void) {
+    assert(flash_state_ == kFlashStateIdle);
+    flash_state_ = kFlashStateErasing;
+    std::thread erase_thread([&]() {
+        // Wait for erase time
+        switch (kFlashType) {
+        case kFlashW25N01G:
+            std::this_thread::sleep_for(
+                std::chrono::milliseconds(10 * kSectors));
+            break;
+        case kFlashW25Q128FV:
+            std::this_thread::sleep_for(std::chrono::seconds(200));
+            break;
+        case kFlashM25P16:
+            std::this_thread::sleep_for(std::chrono::seconds(40));
+            break;
+        case kFlashRAM:
+            break;
+        }
+        memset(&memory_[0], 0xff, kFlashSize);
+        flash_state_ = kFlashStateIdle;
+    });
+    erase_thread.detach();
+}
+void FlashEmulator::flashPageProgramBegin(uint32_t address,
+                                          void (*callback)(uint32_t arg)) {
+    assert(flash_state_ == kFlashStateIdle);
+    writepoint_ = address;
+    write_callback_ = callback;
+    write_buffer_tail_ = 0;
+    memset(&write_buffer_[0], 0x0, kPageSize);
+    //    printf("ProgramBegin: address[0x%x]", address);
+}
+uint32_t FlashEmulator::flashPageProgramContinue(const uint8_t **buffers,
+                                                 uint32_t *bufferSizes,
+                                                 uint32_t bufferCount) {
+    assert(flash_state_ == kFlashStateIdle);
+    uint32_t written = 0;
+    for (uint32_t i = 0; i < bufferCount; i++) {
+        for (uint32_t j = 0; j < bufferSizes[i]; j++) {
+            write_buffer_[write_buffer_tail_] = buffers[i][j];
+            assert(write_buffer_tail_ <= kPageSize);
+            write_buffer_tail_++;
+            written++;
+        }
+    }
+    if (write_buffer_tail_ == kPageSize) {
+        Program();
+    }
+    //    printf("ProgramContinue: written[0x%x]", written);
+    return written;
+}
+void FlashEmulator::flashPageProgramFinish(void) {
+    //    printf("ProgramFinish\n");
+    if (write_buffer_tail_ != 0)
+        Program();
+}
+void FlashEmulator::flashPageProgram(uint32_t address, const uint8_t *data,
+                                     uint32_t length,
+                                     void (*callback)(uint32_t length)) {
+    flashPageProgramBegin(address, callback);
+    flashPageProgramContinue(&data, &length, 1);
+    flashPageProgramFinish();
+}
+int FlashEmulator::flashReadBytes(uint32_t address, uint8_t *buffer,
+                                  uint32_t length) {
+    for (uint32_t i = 0; i < length; i++) {
+        assert(IsValidFlashFSAddress(address));
+        *buffer = memory_[address];
+        buffer++;
+        address++;
+    }
+    return length;
+}
+void FlashEmulator::flashFlush(void) {}
+const flashGeometry_t *FlashEmulator::flashGetGeometry(void) {
+    return &kFlashGeometry;
+}
+
+void FlashEmulator::flashPartitionSet(uint8_t index, uint32_t startSector,
+                                      uint32_t endSector) {
+    // NOP
+    UNUSED(index);
+    UNUSED(startSector);
+    UNUSED(endSector);
+}
+flashPartition_t *
+FlashEmulator::flashPartitionFindByType(flashPartitionType_e type) {
+    if (type == FLASH_PARTITION_TYPE_FLASHFS)
+        return &kFlashFSPartition;
+    return NULL;
+}
+const flashPartition_t *
+FlashEmulator::flashPartitionFindByIndex(uint8_t index) {
+    if (index == 0)
+        return &kFlashFSPartition;
+    return NULL;
+}
+const char *
+FlashEmulator::flashPartitionGetTypeName(flashPartitionType_e type) {
+    UNUSED(type);
+    return "FakeTypeFlashfs";
+}
+int FlashEmulator::flashPartitionCount(void) { return 1; }
+
+void FlashEmulator::Program() {
+    assert(flash_state_ == kFlashStateIdle);
+    flash_state_ = kFlashStateProgramming;
+    std::thread program_thread([&]() {
+        // Wait for program time
+        switch (kFlashType) {
+        case kFlashW25N01G:
+            std::this_thread::sleep_for(std::chrono::microseconds(700));
+            break;
+        case kFlashW25Q128FV:
+            std::this_thread::sleep_for(std::chrono::milliseconds(3));
+            break;
+        case kFlashM25P16:
+            std::this_thread::sleep_for(std::chrono::milliseconds(5));
+            break;
+        case kFlashRAM:
+            break;
+        }
+        // writepoint_ within size
+        assert(IsValidFlashFSAddress(writepoint_));
+
+        // Write to erased page only
+        assert(IsErased(writepoint_, write_buffer_tail_));
+        memcpy(&memory_[writepoint_], &write_buffer_[0], write_buffer_tail_);
+
+        if (write_callback_ != NULL) {
+            write_callback_(write_buffer_tail_);
+        }
+        // If the state becomes idle before callback is called, the flashfs will
+        // overrun and multiple callbacks in different threads will have race.
+        // When running on the real hardware, callback is called from ISR. So by
+        // nature the write can't overrun. Here let's emulate by clearing the
+        // state after callback's done.
+        flash_state_ = kFlashStateIdle;
+    });
+
+    program_thread.detach();
+}
+uint32_t FlashEmulator::GetSectorIndex(uint32_t address) {
+    assert(IsValidFlashFSAddress(address));
+    return address / kSectorSize;
+}
+uint32_t FlashEmulator::GetPageIndex(uint32_t address) {
+    assert(IsValidFlashFSAddress(address));
+    return address / kPageSize;
+}
+bool FlashEmulator::IsErased(uint32_t address, uint32_t length) {
+    for (uint32_t i = 0; i < length; ++i) {
+        if (memory_[address + i] != 0xff) {
+            printf("offset address[0x%x] + i[%d] = %02x\n", address, i,
+                   memory_[address + i]);
+            return false;
+        }
+    }
+    return true;
+}
+bool FlashEmulator::IsValidFlashFSAddress(uint32_t address) {
+    return address >= kFlashFSStartSector * kSectorSize &&
+           address <
+               (kFlashFSStartSector + kFlashFSSizeInSectors) * kSectorSize;
+}
+void FlashEmulator::Fill(uint32_t address, uint8_t byte, uint32_t length) {
+    memset(&memory_[address], byte, length);
+}
+void FlashEmulator::FillSector(uint16_t sector, uint8_t byte, uint16_t count) {
+    memset(&memory_[sector * kSectorSize], byte, count * kSectorSize);
+}

--- a/src/test/unit/flashfs_unittest.include/flash_emulator.h
+++ b/src/test/unit/flashfs_unittest.include/flash_emulator.h
@@ -1,0 +1,147 @@
+/*
+ * This file is part of Rotorflight.
+ *
+ * Rotorflight is free software. You can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Rotorflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+#include "flash_interface.h"
+#include <cstdint>
+#include <memory>
+#include <cassert>
+
+class FlashEmulator : public FlashInterface {
+  public:
+    // Implement Flash Interface
+    void flashPreInit(const flashConfig_t *flashConfig) override;
+    bool flashInit(const flashConfig_t *flashConfig) override;
+
+    bool flashIsReady(void) override;
+    bool flashWaitForReady(void) override;
+    void flashEraseSector(uint32_t address) override;
+    void flashEraseCompletely(void) override;
+    void flashPageProgramBegin(uint32_t address,
+                               void (*callback)(uint32_t arg)) override;
+    uint32_t flashPageProgramContinue(const uint8_t **buffers,
+                                      uint32_t *bufferSizes,
+                                      uint32_t bufferCount) override;
+    void flashPageProgramFinish(void) override;
+    void flashPageProgram(uint32_t address, const uint8_t *data,
+                          uint32_t length,
+                          void (*callback)(uint32_t length)) override;
+    int flashReadBytes(uint32_t address, uint8_t *buffer,
+                       uint32_t length) override;
+    void flashFlush(void) override;
+    const flashGeometry_t *flashGetGeometry(void) override;
+
+    void flashPartitionSet(uint8_t index, uint32_t startSector,
+                           uint32_t endSector) override;
+    flashPartition_t *
+    flashPartitionFindByType(flashPartitionType_e type) override;
+    const flashPartition_t *flashPartitionFindByIndex(uint8_t index) override;
+    const char *flashPartitionGetTypeName(flashPartitionType_e type) override;
+    int flashPartitionCount(void) override;
+
+    ~FlashEmulator() override {}
+
+    // Other internal stuff
+  public:
+    enum FlashType {
+        kFlashW25N01G,
+        kFlashW25Q128FV,
+        kFlashM25P16,
+        kFlashRAM,
+    };
+
+    // Full constructor
+    FlashEmulator(FlashType flash_type, uint16_t page_size,
+                  uint16_t pages_per_sector, uint16_t sectors,
+                  uint16_t flashfs_start, uint16_t flashfs_size)
+        : kFlashType(flash_type), kPageSize(page_size),
+          kPagesPerSector(pages_per_sector), kSectors(sectors),
+          kFlashFSStartSector(flashfs_start),
+          kFlashFSSizeInSectors(flashfs_size),
+
+          kFlashFSPartition({.type = FLASH_PARTITION_TYPE_FLASHFS,
+                             .startSector = flashfs_start,
+                             .endSector = static_cast<uint16_t>(
+                                 flashfs_start + flashfs_size - 1)}),
+          kFlashGeometry({.sectors = kSectors,
+                          .pageSize = kPageSize,
+                          .sectorSize = kSectorSize,
+                          .totalSize = kFlashSize,
+                          .pagesPerSector = kPagesPerSector,
+                          .flashType = flash_type == kFlashW25N01G
+                                           ? FLASH_TYPE_NAND
+                                           : FLASH_TYPE_NOR}) {
+
+        // flash.c and its user (flashfs.c) assumes flashfs partition starts
+        // from 0. Let's make sure the test assume the same.
+        assert(flashfs_start == 0);
+
+        memory_ = std::make_unique<uint8_t[]>(kFlashSize);
+        memset(memory_.get(), 0xff, kFlashSize);
+        write_buffer_ = std::make_unique<uint8_t[]>(kPageSize);
+    }
+
+    // Default geometry
+    FlashEmulator(FlashType flash_type)
+        : FlashEmulator(flash_type, /*page_size=*/2048, /*pages_per_sector=*/4,
+                        /*sectors=*/64, /*flashfs_start=*/0,
+                        /*flashfs_size=*/16) {}
+
+    // Default type and geometry
+    FlashEmulator() : FlashEmulator(kFlashW25N01G) {}
+
+  public:
+    const FlashType kFlashType;
+    const uint16_t kPageSize;
+    const uint16_t kPagesPerSector;
+    const uint16_t kSectors;
+    const uint32_t kSectorSize = kPageSize * kPagesPerSector;
+    const uint32_t kFlashSize = kSectors * kSectorSize;
+    const uint16_t kFlashFSStartSector;
+    const uint16_t kFlashFSStart = kFlashFSStartSector * kSectorSize;
+    const uint16_t kFlashFSSizeInSectors;
+    const uint32_t kFlashFSSize = kFlashFSSizeInSectors * kSectorSize;
+    const uint32_t kFlashFSEnd = kFlashFSStart + kFlashFSSize;  // This is end+1
+
+    flashPartition_t kFlashFSPartition;
+    const flashGeometry_t kFlashGeometry;
+
+    std::unique_ptr<uint8_t[]> memory_ = nullptr;
+    void (*write_callback_)(uint32_t arg) = NULL;
+
+    uint32_t writepoint_ = 0;
+    std::unique_ptr<uint8_t[]> write_buffer_ = nullptr;
+    uint32_t write_buffer_tail_ = 0;
+
+    // Internal flash state.
+    // enum is thread safe (lock-free)
+    enum FlashState {
+        kFlashStateIdle,
+        kFlashStateProgramming,
+        kFlashStateErasing,
+    } flash_state_ = kFlashStateIdle;
+
+    // Reuseable actual "program" cmd
+    void Program();
+    // Helper functions for testing
+    uint32_t GetSectorIndex(uint32_t address);
+    uint32_t GetPageIndex(uint32_t address);
+    bool IsErased(uint32_t address, uint32_t length);
+    bool IsValidFlashFSAddress(uint32_t address);
+    void Fill(uint32_t address, uint8_t byte, uint32_t length);
+    void FillSector(uint16_t sector, uint8_t byte, uint16_t count);
+};

--- a/src/test/unit/flashfs_unittest.include/flash_interface.h
+++ b/src/test/unit/flashfs_unittest.include/flash_interface.h
@@ -1,0 +1,57 @@
+/*
+ * This file is part of Rotorflight.
+ *
+ * Rotorflight is free software. You can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Rotorflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software. If not, see <https://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include "drivers/flash.h"
+#include "pg/flash.h"
+#include <cstdint>
+
+class FlashInterface {
+  public:
+    virtual ~FlashInterface() {};
+
+    virtual void flashPreInit(const flashConfig_t *flashConfig) = 0;
+    virtual bool flashInit(const flashConfig_t *flashConfig) = 0;
+
+    virtual bool flashIsReady(void) = 0;
+    virtual bool flashWaitForReady(void) = 0;
+    virtual void flashEraseSector(uint32_t address) = 0;
+    virtual void flashEraseCompletely(void) = 0;
+    virtual void flashPageProgramBegin(uint32_t address,
+                                       void (*callback)(uint32_t arg)) = 0;
+    virtual uint32_t flashPageProgramContinue(const uint8_t **buffers,
+                                              uint32_t *bufferSizes,
+                                              uint32_t bufferCount) = 0;
+    virtual void flashPageProgramFinish(void) = 0;
+    virtual void flashPageProgram(uint32_t address, const uint8_t *data,
+                                  uint32_t length,
+                                  void (*callback)(uint32_t length)) = 0;
+    virtual int flashReadBytes(uint32_t address, uint8_t *buffer,
+                               uint32_t length) = 0;
+    virtual void flashFlush(void) = 0;
+    virtual const flashGeometry_t *flashGetGeometry(void) = 0;
+
+    virtual void flashPartitionSet(uint8_t index, uint32_t startSector,
+                                   uint32_t endSector) = 0;
+    virtual flashPartition_t *
+    flashPartitionFindByType(flashPartitionType_e type) = 0;
+    virtual const flashPartition_t *
+    flashPartitionFindByIndex(uint8_t index) = 0;
+    virtual const char *
+    flashPartitionGetTypeName(flashPartitionType_e type) = 0;
+    virtual int flashPartitionCount(void) = 0;
+};

--- a/src/test/unit/flashfs_unittest.include/flash_mock.h
+++ b/src/test/unit/flashfs_unittest.include/flash_mock.h
@@ -1,0 +1,54 @@
+/*
+ * This file is part of Rotorflight.
+ *
+ * Rotorflight is free software. You can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Rotorflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+#include "gmock/gmock.h"
+
+#include "flash_interface.h"
+#include "flash_emulator.h"
+
+class FlashMock : public FlashInterface {
+  public:
+    MOCK_METHOD(void, flashPreInit, (const flashConfig_t *flashConfig), (override));
+    MOCK_METHOD(bool, flashInit, (const flashConfig_t *flashConfig), (override));
+    MOCK_METHOD(bool, flashIsReady, (), (override));
+    MOCK_METHOD(bool, flashWaitForReady, (), (override));
+    MOCK_METHOD(void, flashEraseSector, (uint32_t address), (override));
+    MOCK_METHOD(void, flashEraseCompletely, (), (override));
+    MOCK_METHOD(void, flashPageProgramBegin,
+                (uint32_t address, void (*callback)(uint32_t arg)), (override));
+    MOCK_METHOD(uint32_t, flashPageProgramContinue,
+                (const uint8_t **buffers, uint32_t *bufferSizes,
+                 uint32_t bufferCount), (override));
+    MOCK_METHOD(void, flashPageProgramFinish, (), (override));
+    MOCK_METHOD(void, flashPageProgram,
+                (uint32_t address, const uint8_t *data, uint32_t length,
+                 void (*callback)(uint32_t length)), (override));
+    MOCK_METHOD(int, flashReadBytes,
+                (uint32_t address, uint8_t *buffer, uint32_t length), (override));
+    MOCK_METHOD(void, flashFlush, (), (override));
+    MOCK_METHOD(const flashGeometry_t *, flashGetGeometry, (), (override));
+    MOCK_METHOD(void, flashPartitionSet,
+                (uint8_t index, uint32_t startSector, uint32_t endSector), (override));
+    MOCK_METHOD(flashPartition_t *, flashPartitionFindByType,
+                (flashPartitionType_e type), (override));
+    MOCK_METHOD(const flashPartition_t *, flashPartitionFindByIndex,
+                (uint8_t index), (override));
+    MOCK_METHOD(const char *, flashPartitionGetTypeName,
+                (flashPartitionType_e type), (override));
+    MOCK_METHOD(int, flashPartitionCount, (), (override));
+};

--- a/src/test/unit/unittest_platform.h
+++ b/src/test/unit/unittest_platform.h
@@ -34,6 +34,10 @@
 #define INIT_CODE
 #define INIT_ZERO  { 0, }
 
+#define DMA_DATA_ZERO_INIT
+#define DMA_DATA
+#define STATIC_DMA_DATA_AUTO        static
+
 #define	__unused	__attribute__((__unused__))
 
 #define PID_PROFILE_COUNT 3


### PR DESCRIPTION
This PR is based off PR #209. It implements rolling erase.

Background: https://github.com/rotorflight/rotorflight-firmware/issues/126#issuecomment-2521562367 bullet 3

`set blackbox_rolling_erase = ON` to turn it on (default is off).

The feature is tested on Matek G474Heli and Flydragon, both have w25n01g flash chip whose sector erase is ~2ms.

If the sector erase is slower, there will be buffer drops and log gaps, which is generally fine (tested). However, the exact behavior on other flash chips is untested and there may be room for improvements (e.g., erase suspend, larger buffer).