### PR TITLE
Tail PD scaling

### DIFF
--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -1201,12 +1201,10 @@ const clivalue_t valueTable[] = {
     { "gov_min_throttle",           VAR_UINT8  |  PROFILE_VALUE,  .config.minmaxUnsigned = { 0, 100 }, PG_PID_PROFILE, offsetof(pidProfile_t, governor.min_throttle) },
 
     { "scale_p_yaw",                VAR_UINT8  |  PROFILE_VALUE,  .config.minmaxUnsigned = { 0, 50 }, PG_PID_PROFILE, offsetof(pidProfile_t, scale_p_yaw) },
-    { "scale_p_yaw_d",              VAR_UINT8  |  PROFILE_VALUE,  .config.minmaxUnsigned = { 0, 250 }, PG_PID_PROFILE, offsetof(pidProfile_t, scale_p_yaw_d) },
-    { "scale_p_yaw_d_cutoff",       VAR_UINT8  |  PROFILE_VALUE,  .config.minmaxUnsigned = { 0, 250 }, PG_PID_PROFILE, offsetof(pidProfile_t, scale_p_yaw_d_cutoff) },
-    { "scale_p_collective",         VAR_UINT8  |  PROFILE_VALUE,  .config.minmaxUnsigned = { 0, 50 }, PG_PID_PROFILE, offsetof(pidProfile_t, scale_p_collective) },
-    { "scale_p_collective_tau",     VAR_UINT8  |  PROFILE_VALUE,  .config.minmaxUnsigned = { 1, 250 }, PG_PID_PROFILE, offsetof(pidProfile_t, scale_p_collective_tau) },
     { "scale_d_yaw",                VAR_UINT8  |  PROFILE_VALUE,  .config.minmaxUnsigned = { 0, 50 }, PG_PID_PROFILE, offsetof(pidProfile_t, scale_d_yaw) },
+    { "scale_p_collective",         VAR_UINT8  |  PROFILE_VALUE,  .config.minmaxUnsigned = { 0, 50 }, PG_PID_PROFILE, offsetof(pidProfile_t, scale_p_collective) },
     { "scale_d_collective",         VAR_UINT8  |  PROFILE_VALUE,  .config.minmaxUnsigned = { 0, 50 }, PG_PID_PROFILE, offsetof(pidProfile_t, scale_d_collective) },
+    { "scale_collective_tau10",     VAR_UINT8  |  PROFILE_VALUE,  .config.minmaxUnsigned = { 1, 250 }, PG_PID_PROFILE, offsetof(pidProfile_t, scale_collective_tau10) },
 
 // PG_TELEMETRY_CONFIG
 #ifdef USE_TELEMETRY

--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -1202,6 +1202,7 @@ const clivalue_t valueTable[] = {
 
     { "p_scale_yaw",                VAR_UINT8  |  PROFILE_VALUE,  .config.minmaxUnsigned = { 0, 50 }, PG_PID_PROFILE, offsetof(pidProfile_t, p_scale_yaw) },
     { "p_scale_collective",         VAR_UINT8  |  PROFILE_VALUE,  .config.minmaxUnsigned = { 0, 50 }, PG_PID_PROFILE, offsetof(pidProfile_t, p_scale_collective) },
+    { "p_scale_collective_tau",     VAR_UINT8  |  PROFILE_VALUE,  .config.minmaxUnsigned = { 1, 250 }, PG_PID_PROFILE, offsetof(pidProfile_t, p_scale_collective_tau) },
 
 // PG_TELEMETRY_CONFIG
 #ifdef USE_TELEMETRY

--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -1200,10 +1200,10 @@ const clivalue_t valueTable[] = {
     { "gov_max_throttle",           VAR_UINT8  |  PROFILE_VALUE,  .config.minmaxUnsigned = { 0, 100 }, PG_PID_PROFILE, offsetof(pidProfile_t, governor.max_throttle) },
     { "gov_min_throttle",           VAR_UINT8  |  PROFILE_VALUE,  .config.minmaxUnsigned = { 0, 100 }, PG_PID_PROFILE, offsetof(pidProfile_t, governor.min_throttle) },
 
-    { "scale_p_yaw",                VAR_UINT8  |  PROFILE_VALUE,  .config.minmaxUnsigned = { 0, 50 }, PG_PID_PROFILE, offsetof(pidProfile_t, scale_p_yaw) },
-    { "scale_d_yaw",                VAR_UINT8  |  PROFILE_VALUE,  .config.minmaxUnsigned = { 0, 50 }, PG_PID_PROFILE, offsetof(pidProfile_t, scale_d_yaw) },
-    { "scale_p_collective",         VAR_UINT8  |  PROFILE_VALUE,  .config.minmaxUnsigned = { 0, 50 }, PG_PID_PROFILE, offsetof(pidProfile_t, scale_p_collective) },
-    { "scale_d_collective",         VAR_UINT8  |  PROFILE_VALUE,  .config.minmaxUnsigned = { 0, 50 }, PG_PID_PROFILE, offsetof(pidProfile_t, scale_d_collective) },
+    { "scale_p_yaw",                VAR_UINT8  |  PROFILE_VALUE,  .config.minmaxUnsigned = { 0, 100 }, PG_PID_PROFILE, offsetof(pidProfile_t, scale_p_yaw) },
+    { "scale_d_yaw",                VAR_UINT8  |  PROFILE_VALUE,  .config.minmaxUnsigned = { 0, 100 }, PG_PID_PROFILE, offsetof(pidProfile_t, scale_d_yaw) },
+    { "scale_p_collective",         VAR_UINT8  |  PROFILE_VALUE,  .config.minmaxUnsigned = { 0, 100 }, PG_PID_PROFILE, offsetof(pidProfile_t, scale_p_collective) },
+    { "scale_d_collective",         VAR_UINT8  |  PROFILE_VALUE,  .config.minmaxUnsigned = { 0, 100 }, PG_PID_PROFILE, offsetof(pidProfile_t, scale_d_collective) },
     { "scale_collective_tau10",     VAR_UINT8  |  PROFILE_VALUE,  .config.minmaxUnsigned = { 1, 250 }, PG_PID_PROFILE, offsetof(pidProfile_t, scale_collective_tau10) },
 
 // PG_TELEMETRY_CONFIG

--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -1200,6 +1200,9 @@ const clivalue_t valueTable[] = {
     { "gov_max_throttle",           VAR_UINT8  |  PROFILE_VALUE,  .config.minmaxUnsigned = { 0, 100 }, PG_PID_PROFILE, offsetof(pidProfile_t, governor.max_throttle) },
     { "gov_min_throttle",           VAR_UINT8  |  PROFILE_VALUE,  .config.minmaxUnsigned = { 0, 100 }, PG_PID_PROFILE, offsetof(pidProfile_t, governor.min_throttle) },
 
+    { "p_scale_yaw",                VAR_UINT8  |  PROFILE_VALUE,  .config.minmaxUnsigned = { 0, 50 }, PG_PID_PROFILE, offsetof(pidProfile_t, p_scale_yaw) },
+    { "p_scale_collective",         VAR_UINT8  |  PROFILE_VALUE,  .config.minmaxUnsigned = { 0, 50 }, PG_PID_PROFILE, offsetof(pidProfile_t, p_scale_collective) },
+
 // PG_TELEMETRY_CONFIG
 #ifdef USE_TELEMETRY
     { "tlm_inverted",               VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_TELEMETRY_CONFIG, offsetof(telemetryConfig_t, telemetry_inverted) },

--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -1200,11 +1200,13 @@ const clivalue_t valueTable[] = {
     { "gov_max_throttle",           VAR_UINT8  |  PROFILE_VALUE,  .config.minmaxUnsigned = { 0, 100 }, PG_PID_PROFILE, offsetof(pidProfile_t, governor.max_throttle) },
     { "gov_min_throttle",           VAR_UINT8  |  PROFILE_VALUE,  .config.minmaxUnsigned = { 0, 100 }, PG_PID_PROFILE, offsetof(pidProfile_t, governor.min_throttle) },
 
-    { "p_scale_yaw",                VAR_UINT8  |  PROFILE_VALUE,  .config.minmaxUnsigned = { 0, 50 }, PG_PID_PROFILE, offsetof(pidProfile_t, p_scale_yaw) },
-    { "p_scale_yaw_d",              VAR_UINT8  |  PROFILE_VALUE,  .config.minmaxUnsigned = { 0, 250 }, PG_PID_PROFILE, offsetof(pidProfile_t, p_scale_yaw_d) },
-    { "p_scale_yaw_d_cutoff",       VAR_UINT8  |  PROFILE_VALUE,  .config.minmaxUnsigned = { 0, 250 }, PG_PID_PROFILE, offsetof(pidProfile_t, p_scale_yaw_d_cutoff) },
-    { "p_scale_collective",         VAR_UINT8  |  PROFILE_VALUE,  .config.minmaxUnsigned = { 0, 50 }, PG_PID_PROFILE, offsetof(pidProfile_t, p_scale_collective) },
-    { "p_scale_collective_tau",     VAR_UINT8  |  PROFILE_VALUE,  .config.minmaxUnsigned = { 1, 250 }, PG_PID_PROFILE, offsetof(pidProfile_t, p_scale_collective_tau) },
+    { "scale_p_yaw",                VAR_UINT8  |  PROFILE_VALUE,  .config.minmaxUnsigned = { 0, 50 }, PG_PID_PROFILE, offsetof(pidProfile_t, scale_p_yaw) },
+    { "scale_p_yaw_d",              VAR_UINT8  |  PROFILE_VALUE,  .config.minmaxUnsigned = { 0, 250 }, PG_PID_PROFILE, offsetof(pidProfile_t, scale_p_yaw_d) },
+    { "scale_p_yaw_d_cutoff",       VAR_UINT8  |  PROFILE_VALUE,  .config.minmaxUnsigned = { 0, 250 }, PG_PID_PROFILE, offsetof(pidProfile_t, scale_p_yaw_d_cutoff) },
+    { "scale_p_collective",         VAR_UINT8  |  PROFILE_VALUE,  .config.minmaxUnsigned = { 0, 50 }, PG_PID_PROFILE, offsetof(pidProfile_t, scale_p_collective) },
+    { "scale_p_collective_tau",     VAR_UINT8  |  PROFILE_VALUE,  .config.minmaxUnsigned = { 1, 250 }, PG_PID_PROFILE, offsetof(pidProfile_t, scale_p_collective_tau) },
+    { "scale_d_yaw",                VAR_UINT8  |  PROFILE_VALUE,  .config.minmaxUnsigned = { 0, 50 }, PG_PID_PROFILE, offsetof(pidProfile_t, scale_d_yaw) },
+    { "scale_d_collective",         VAR_UINT8  |  PROFILE_VALUE,  .config.minmaxUnsigned = { 0, 50 }, PG_PID_PROFILE, offsetof(pidProfile_t, scale_d_collective) },
 
 // PG_TELEMETRY_CONFIG
 #ifdef USE_TELEMETRY

--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -1201,6 +1201,8 @@ const clivalue_t valueTable[] = {
     { "gov_min_throttle",           VAR_UINT8  |  PROFILE_VALUE,  .config.minmaxUnsigned = { 0, 100 }, PG_PID_PROFILE, offsetof(pidProfile_t, governor.min_throttle) },
 
     { "p_scale_yaw",                VAR_UINT8  |  PROFILE_VALUE,  .config.minmaxUnsigned = { 0, 50 }, PG_PID_PROFILE, offsetof(pidProfile_t, p_scale_yaw) },
+    { "p_scale_yaw_d",              VAR_UINT8  |  PROFILE_VALUE,  .config.minmaxUnsigned = { 0, 250 }, PG_PID_PROFILE, offsetof(pidProfile_t, p_scale_yaw_d) },
+    { "p_scale_yaw_d_cutoff",       VAR_UINT8  |  PROFILE_VALUE,  .config.minmaxUnsigned = { 0, 250 }, PG_PID_PROFILE, offsetof(pidProfile_t, p_scale_yaw_d_cutoff) },
     { "p_scale_collective",         VAR_UINT8  |  PROFILE_VALUE,  .config.minmaxUnsigned = { 0, 50 }, PG_PID_PROFILE, offsetof(pidProfile_t, p_scale_collective) },
     { "p_scale_collective_tau",     VAR_UINT8  |  PROFILE_VALUE,  .config.minmaxUnsigned = { 1, 250 }, PG_PID_PROFILE, offsetof(pidProfile_t, p_scale_collective_tau) },
 

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -1183,10 +1183,15 @@ static void pidApplyYawMode3(const pidProfile_t *pidProfile)
 
   //// P-term
     // Experimental: calculate scale
-    const float Kp_scale_yaw = (1.0f - fabsf(gyroRate) / 360 * pidProfile->scale_p_yaw / 100.0f);
     const float dampedCollectiveDeflectAbs = filterApply(&pid.scale_collective_filter, getCollectiveDeflectionAbs());
-    const float Kp_scale_collective = 1.0f - dampedCollectiveDeflectAbs * pidProfile->scale_p_collective / 100.0f;
-    const float Kp_scale = constrainf(Kp_scale_yaw * Kp_scale_collective, 0.0f, 3.0f);
+    const float Kp_scale_yaw = scaleRangef(fabsf(gyroRate),
+                                           0.0f, 360.0f,
+                                           1.0f, pidProfile->scale_p_yaw / 100.0f);
+    const float Kp_scale_collective =
+        scaleRangef(dampedCollectiveDeflectAbs,
+                    0.0f, 1.0f,
+                    1.0f, pidProfile->scale_p_collective / 100.0f);
+    const float Kp_scale = constrainf(Kp_scale_yaw * Kp_scale_collective, 0.0f, 2.0f);
 
     // Calculate P-component
     pid.data[axis].P = pid.coef[axis].Kp * errorRate * stopGain * Kp_scale;
@@ -1194,9 +1199,14 @@ static void pidApplyYawMode3(const pidProfile_t *pidProfile)
 
   //// D-term
     // Experimental: calculate scale
-    const float Kd_scale_yaw = (1.0f - fabsf(gyroRate) / 360 * pidProfile->scale_p_yaw / 100.0f);
-    const float Kd_scale_collective = 1.0f - dampedCollectiveDeflectAbs * pidProfile->scale_d_collective / 100.0f;
-    const float Kd_scale = constrainf(Kd_scale_yaw * Kd_scale_collective, 0.0f, 3.0f);
+    const float Kd_scale_yaw = scaleRangef(fabsf(gyroRate),
+                                           0.0f, 360.0f,
+                                           1.0f, pidProfile->scale_d_yaw / 100.0f);
+    const float Kd_scale_collective =
+        scaleRangef(dampedCollectiveDeflectAbs,
+                    0.0f, 1.0f,
+                    1.0f, pidProfile->scale_d_collective / 100.0f);
+    const float Kd_scale = constrainf(Kd_scale_yaw * Kd_scale_collective, 0.0f, 2.0f);
 
     // Select D-term on error or gyro
     const float dError = pid.dtermModeYaw ? errorRate : -gyroRate;

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -1183,7 +1183,7 @@ static void pidApplyYawMode3(const pidProfile_t *pidProfile)
   //// P-term
 
     float dampedCollectiveDeflectAbs = filterApply(&pid.p_scale_collective_filter, getCollectiveDeflectionAbs());
-    float Kp_scale = (1.0f - getYawDeflectionAbs() * pidProfile->p_scale_yaw / 100.0f);
+    float Kp_scale = (1.0f - fabsf(gyroRate) / 480 * pidProfile->p_scale_yaw / 100.0f);
     Kp_scale *= (1.0f - dampedCollectiveDeflectAbs * pidProfile->p_scale_collective / 100.0f);
     Kp_scale = constrainf(Kp_scale, 0.0f, 1.0f);
 

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -1187,12 +1187,12 @@ static void pidApplyYawMode3(const pidProfile_t *pidProfile)
     const float Kp_scale_yaw = (1.0f - fabsf(gyroRate) / 480 * pidProfile->p_scale_yaw / 100.0f);
 
     float Kp_scale_yaw_dterm = difFilterApply(&pid.p_scale_yaw_d_filter, setpoint);
-    const float Kp_scale_yaw_d = (1.0f - fabsf(Kp_scale_yaw_dterm) * pidProfile->p_scale_yaw / 100.0f);
+    const float Kp_scale_yaw_d = (1.0f + fabsf(Kp_scale_yaw_dterm) * pidProfile->p_scale_yaw_d / 100.0f / 5000);
 
     float dampedCollectiveDeflectAbs = filterApply(&pid.p_scale_collective_filter, getCollectiveDeflectionAbs());
     const float Kp_scale_collective = 1.0f - dampedCollectiveDeflectAbs * pidProfile->p_scale_collective / 100.0f;
 
-    const float Kp_scale = constrainf(Kp_scale_yaw * Kp_scale_yaw_d * Kp_scale_collective, 0.0f, 1.0f);
+    const float Kp_scale = constrainf(Kp_scale_yaw * Kp_scale_yaw_d * Kp_scale_collective, 0.0f, 3.0f);
 
     // Calculate P-component
     pid.data[axis].P = pid.coef[axis].Kp * errorRate * stopGain * Kp_scale;

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -136,7 +136,7 @@ typedef struct pid_s {
 
     pt1Filter_t offsetFloodRelaxFilter;
     difFilter_t p_scale_yaw_d_filter;
-    filter_t p_scale_collective_filter;
+    filter_t scale_p_collective_filter;
 } pid_t;
 
 

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -135,6 +135,7 @@ typedef struct pid_s {
     order1Filter_t crossCouplingFilter[XY_AXIS_COUNT];
 
     pt1Filter_t offsetFloodRelaxFilter;
+    difFilter_t p_scale_yaw_d_filter;
     filter_t p_scale_collective_filter;
 } pid_t;
 

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -135,8 +135,7 @@ typedef struct pid_s {
     order1Filter_t crossCouplingFilter[XY_AXIS_COUNT];
 
     pt1Filter_t offsetFloodRelaxFilter;
-    difFilter_t p_scale_yaw_d_filter;
-    filter_t scale_p_collective_filter;
+    filter_t scale_collective_filter;
 } pid_t;
 
 

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -135,6 +135,7 @@ typedef struct pid_s {
     order1Filter_t crossCouplingFilter[XY_AXIS_COUNT];
 
     pt1Filter_t offsetFloodRelaxFilter;
+    filter_t p_scale_collective_filter;
 } pid_t;
 
 

--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -1014,6 +1014,8 @@ static bool mspCommonProcessOutCommand(int16_t cmdMSP, sbuf_t *dst, mspPostProce
          * sbufWriteU8(dst, currentPidProfile->yourFancyParameterB);
          */
         sbufWriteU8(dst, currentPidProfile->p_scale_yaw);
+        sbufWriteU8(dst, currentPidProfile->p_scale_yaw_d);
+        sbufWriteU8(dst, currentPidProfile->p_scale_yaw_d_cutoff);
         sbufWriteU8(dst, currentPidProfile->p_scale_collective);
         sbufWriteU8(dst, currentPidProfile->p_scale_collective_tau);
         break;
@@ -3655,6 +3657,8 @@ static mspResult_e mspCommonProcessInCommand(mspDescriptor_t srcDesc, int16_t cm
          */
         if (sbufBytesRemaining(src) >= 3) {
             currentPidProfile->p_scale_yaw = sbufReadU8(src);
+            currentPidProfile->p_scale_yaw_d = sbufReadU8(src);
+            currentPidProfile->p_scale_yaw_d_cutoff = sbufReadU8(src);
             currentPidProfile->p_scale_collective = sbufReadU8(src);
             currentPidProfile->p_scale_collective_tau = sbufReadU8(src);
             if (currentPidProfile->p_scale_collective_tau == 0) {

--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -1014,12 +1014,10 @@ static bool mspCommonProcessOutCommand(int16_t cmdMSP, sbuf_t *dst, mspPostProce
          * sbufWriteU8(dst, currentPidProfile->yourFancyParameterB);
          */
         sbufWriteU8(dst, currentPidProfile->scale_p_yaw);
-        sbufWriteU8(dst, currentPidProfile->scale_p_yaw_d);
-        sbufWriteU8(dst, currentPidProfile->scale_p_yaw_d_cutoff);
-        sbufWriteU8(dst, currentPidProfile->scale_p_collective);
-        sbufWriteU8(dst, currentPidProfile->scale_p_collective_tau);
         sbufWriteU8(dst, currentPidProfile->scale_d_yaw);
+        sbufWriteU8(dst, currentPidProfile->scale_p_collective);
         sbufWriteU8(dst, currentPidProfile->scale_d_collective);
+        sbufWriteU8(dst, currentPidProfile->scale_collective_tau10);
         break;
 
     default:
@@ -3657,16 +3655,14 @@ static mspResult_e mspCommonProcessInCommand(mspDescriptor_t srcDesc, int16_t cm
          *     currentPidProfile->yourFancyParameterB = sbufReadU8(src);
          * }
          */
-        if (sbufBytesRemaining(src) >= 7) {
+        if (sbufBytesRemaining(src) >= 5) {
             currentPidProfile->scale_p_yaw = sbufReadU8(src);
-            currentPidProfile->scale_p_yaw_d = sbufReadU8(src);
-            currentPidProfile->scale_p_yaw_d_cutoff = sbufReadU8(src);
-            currentPidProfile->scale_p_collective = sbufReadU8(src);
-            currentPidProfile->scale_p_collective_tau = sbufReadU8(src);
             currentPidProfile->scale_d_yaw = sbufReadU8(src);
+            currentPidProfile->scale_p_collective = sbufReadU8(src);
             currentPidProfile->scale_d_collective = sbufReadU8(src);
-            if (currentPidProfile->scale_p_collective_tau == 0) {
-                currentPidProfile->scale_p_collective_tau = 1;
+            currentPidProfile->scale_collective_tau10 = sbufReadU8(src);
+            if (currentPidProfile->scale_collective_tau10 == 0) {
+                currentPidProfile->scale_collective_tau10 = 1;
             }
         }
         break;

--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -1013,6 +1013,8 @@ static bool mspCommonProcessOutCommand(int16_t cmdMSP, sbuf_t *dst, mspPostProce
          * sbufWriteU8(dst, currentPidProfile->yourFancyParameterA);
          * sbufWriteU8(dst, currentPidProfile->yourFancyParameterB);
          */
+        sbufWriteU8(dst, currentPidProfile->p_scale_yaw);
+        sbufWriteU8(dst, currentPidProfile->p_scale_collective);
         break;
 
     default:
@@ -3650,6 +3652,10 @@ static mspResult_e mspCommonProcessInCommand(mspDescriptor_t srcDesc, int16_t cm
          *     currentPidProfile->yourFancyParameterB = sbufReadU8(src);
          * }
          */
+        if (sbufBytesRemaining(src) >= 2) {
+            currentPidProfile->p_scale_yaw = sbufReadU8(src);
+            currentPidProfile->p_scale_collective = sbufReadU8(src);
+        }
         break;
 
     default:

--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -1015,6 +1015,7 @@ static bool mspCommonProcessOutCommand(int16_t cmdMSP, sbuf_t *dst, mspPostProce
          */
         sbufWriteU8(dst, currentPidProfile->p_scale_yaw);
         sbufWriteU8(dst, currentPidProfile->p_scale_collective);
+        sbufWriteU8(dst, currentPidProfile->p_scale_collective_tau);
         break;
 
     default:
@@ -3652,9 +3653,13 @@ static mspResult_e mspCommonProcessInCommand(mspDescriptor_t srcDesc, int16_t cm
          *     currentPidProfile->yourFancyParameterB = sbufReadU8(src);
          * }
          */
-        if (sbufBytesRemaining(src) >= 2) {
+        if (sbufBytesRemaining(src) >= 3) {
             currentPidProfile->p_scale_yaw = sbufReadU8(src);
             currentPidProfile->p_scale_collective = sbufReadU8(src);
+            currentPidProfile->p_scale_collective_tau = sbufReadU8(src);
+            if (currentPidProfile->p_scale_collective_tau == 0) {
+                currentPidProfile->p_scale_collective_tau = 1;
+            }
         }
         break;
 

--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -1013,11 +1013,13 @@ static bool mspCommonProcessOutCommand(int16_t cmdMSP, sbuf_t *dst, mspPostProce
          * sbufWriteU8(dst, currentPidProfile->yourFancyParameterA);
          * sbufWriteU8(dst, currentPidProfile->yourFancyParameterB);
          */
-        sbufWriteU8(dst, currentPidProfile->p_scale_yaw);
-        sbufWriteU8(dst, currentPidProfile->p_scale_yaw_d);
-        sbufWriteU8(dst, currentPidProfile->p_scale_yaw_d_cutoff);
-        sbufWriteU8(dst, currentPidProfile->p_scale_collective);
-        sbufWriteU8(dst, currentPidProfile->p_scale_collective_tau);
+        sbufWriteU8(dst, currentPidProfile->scale_p_yaw);
+        sbufWriteU8(dst, currentPidProfile->scale_p_yaw_d);
+        sbufWriteU8(dst, currentPidProfile->scale_p_yaw_d_cutoff);
+        sbufWriteU8(dst, currentPidProfile->scale_p_collective);
+        sbufWriteU8(dst, currentPidProfile->scale_p_collective_tau);
+        sbufWriteU8(dst, currentPidProfile->scale_d_yaw);
+        sbufWriteU8(dst, currentPidProfile->scale_d_collective);
         break;
 
     default:
@@ -3655,14 +3657,16 @@ static mspResult_e mspCommonProcessInCommand(mspDescriptor_t srcDesc, int16_t cm
          *     currentPidProfile->yourFancyParameterB = sbufReadU8(src);
          * }
          */
-        if (sbufBytesRemaining(src) >= 3) {
-            currentPidProfile->p_scale_yaw = sbufReadU8(src);
-            currentPidProfile->p_scale_yaw_d = sbufReadU8(src);
-            currentPidProfile->p_scale_yaw_d_cutoff = sbufReadU8(src);
-            currentPidProfile->p_scale_collective = sbufReadU8(src);
-            currentPidProfile->p_scale_collective_tau = sbufReadU8(src);
-            if (currentPidProfile->p_scale_collective_tau == 0) {
-                currentPidProfile->p_scale_collective_tau = 1;
+        if (sbufBytesRemaining(src) >= 7) {
+            currentPidProfile->scale_p_yaw = sbufReadU8(src);
+            currentPidProfile->scale_p_yaw_d = sbufReadU8(src);
+            currentPidProfile->scale_p_yaw_d_cutoff = sbufReadU8(src);
+            currentPidProfile->scale_p_collective = sbufReadU8(src);
+            currentPidProfile->scale_p_collective_tau = sbufReadU8(src);
+            currentPidProfile->scale_d_yaw = sbufReadU8(src);
+            currentPidProfile->scale_d_collective = sbufReadU8(src);
+            if (currentPidProfile->scale_p_collective_tau == 0) {
+                currentPidProfile->scale_p_collective_tau = 1;
             }
         }
         break;

--- a/src/main/pg/pid.c
+++ b/src/main/pg/pid.c
@@ -129,6 +129,7 @@ void resetPidProfile(pidProfile_t *pidProfile)
         .governor.collective_ff_weight = 100,
         .governor.max_throttle = 100,
         .governor.min_throttle = 10,
+        .p_scale_yaw_d_cutoff = 25,
         .p_scale_collective_tau = 30,
     );
 }

--- a/src/main/pg/pid.c
+++ b/src/main/pg/pid.c
@@ -130,12 +130,10 @@ void resetPidProfile(pidProfile_t *pidProfile)
         .governor.max_throttle = 100,
         .governor.min_throttle = 10,
         .scale_p_yaw = 20,
-        .scale_p_yaw_d = 0,
-        .scale_p_yaw_d_cutoff = 25,
-        .scale_p_collective = 20,
-        .scale_p_collective_tau = 30,
         .scale_d_yaw = 20,
-        .scale_d_collective = 20,
+        .scale_p_collective = 30,
+        .scale_d_collective = 30,
+        .scale_collective_tau10 = 20,
     );
 }
 

--- a/src/main/pg/pid.c
+++ b/src/main/pg/pid.c
@@ -129,6 +129,7 @@ void resetPidProfile(pidProfile_t *pidProfile)
         .governor.collective_ff_weight = 100,
         .governor.max_throttle = 100,
         .governor.min_throttle = 10,
+        .p_scale_collective_tau = 30,
     );
 }
 

--- a/src/main/pg/pid.c
+++ b/src/main/pg/pid.c
@@ -129,8 +129,13 @@ void resetPidProfile(pidProfile_t *pidProfile)
         .governor.collective_ff_weight = 100,
         .governor.max_throttle = 100,
         .governor.min_throttle = 10,
-        .p_scale_yaw_d_cutoff = 25,
-        .p_scale_collective_tau = 30,
+        .scale_p_yaw = 20,
+        .scale_p_yaw_d = 0,
+        .scale_p_yaw_d_cutoff = 25,
+        .scale_p_collective = 20,
+        .scale_p_collective_tau = 30,
+        .scale_d_yaw = 20,
+        .scale_d_collective = 20,
     );
 }
 

--- a/src/main/pg/pid.c
+++ b/src/main/pg/pid.c
@@ -129,10 +129,10 @@ void resetPidProfile(pidProfile_t *pidProfile)
         .governor.collective_ff_weight = 100,
         .governor.max_throttle = 100,
         .governor.min_throttle = 10,
-        .scale_p_yaw = 20,
-        .scale_d_yaw = 20,
-        .scale_p_collective = 30,
-        .scale_d_collective = 30,
+        .scale_p_yaw = 80,
+        .scale_d_yaw = 80,
+        .scale_p_collective = 70,
+        .scale_d_collective = 70,
         .scale_collective_tau10 = 20,
     );
 }

--- a/src/main/pg/pid.h
+++ b/src/main/pg/pid.h
@@ -186,6 +186,7 @@ typedef struct pidProfile_s {
 
     uint8_t             p_scale_yaw;
     uint8_t             p_scale_collective;
+    uint8_t             p_scale_collective_tau;
 } pidProfile_t;
 
 PG_DECLARE_ARRAY(pidProfile_t, PID_PROFILE_COUNT, pidProfiles);

--- a/src/main/pg/pid.h
+++ b/src/main/pg/pid.h
@@ -185,12 +185,10 @@ typedef struct pidProfile_s {
     governorProfile_t   governor;
 
     uint8_t             scale_p_yaw;
-    uint8_t             scale_p_yaw_d;
-    uint8_t             scale_p_yaw_d_cutoff;
-    uint8_t             scale_p_collective;
-    uint8_t             scale_p_collective_tau;
     uint8_t             scale_d_yaw;
+    uint8_t             scale_p_collective;
     uint8_t             scale_d_collective;
+    uint8_t             scale_collective_tau10;
 } pidProfile_t;
 
 PG_DECLARE_ARRAY(pidProfile_t, PID_PROFILE_COUNT, pidProfiles);

--- a/src/main/pg/pid.h
+++ b/src/main/pg/pid.h
@@ -184,6 +184,8 @@ typedef struct pidProfile_s {
     pidRescueConfig_t   rescue;
     governorProfile_t   governor;
 
+    uint8_t             p_scale_yaw;
+    uint8_t             p_scale_collective;
 } pidProfile_t;
 
 PG_DECLARE_ARRAY(pidProfile_t, PID_PROFILE_COUNT, pidProfiles);

--- a/src/main/pg/pid.h
+++ b/src/main/pg/pid.h
@@ -185,6 +185,8 @@ typedef struct pidProfile_s {
     governorProfile_t   governor;
 
     uint8_t             p_scale_yaw;
+    uint8_t             p_scale_yaw_d;
+    uint8_t             p_scale_yaw_d_cutoff;
     uint8_t             p_scale_collective;
     uint8_t             p_scale_collective_tau;
 } pidProfile_t;

--- a/src/main/pg/pid.h
+++ b/src/main/pg/pid.h
@@ -184,11 +184,13 @@ typedef struct pidProfile_s {
     pidRescueConfig_t   rescue;
     governorProfile_t   governor;
 
-    uint8_t             p_scale_yaw;
-    uint8_t             p_scale_yaw_d;
-    uint8_t             p_scale_yaw_d_cutoff;
-    uint8_t             p_scale_collective;
-    uint8_t             p_scale_collective_tau;
+    uint8_t             scale_p_yaw;
+    uint8_t             scale_p_yaw_d;
+    uint8_t             scale_p_yaw_d_cutoff;
+    uint8_t             scale_p_collective;
+    uint8_t             scale_p_collective_tau;
+    uint8_t             scale_d_yaw;
+    uint8_t             scale_d_collective;
 } pidProfile_t;
 
 PG_DECLARE_ARRAY(pidProfile_t, PID_PROFILE_COUNT, pidProfiles);


### PR DESCRIPTION
This is an experimental feature (https://github.com/rotorflight/rotorflight-firmware/issues/234)

New cli params:
  * scale_p_yaw: reduction of P gain when rotating 360°/s. (value 80 -> Kp *= 0.80).
  * scale_d_yaw: reduction of D gain....
  * scale_p_collective: reduction of P gain when +-15°. (value 70 -> Kp *= 0.70).
  * scale_d_collective: reduction of D gain....
  * scale_collective_tau10: time constant of collective low pass (10x). (value 20 -> 2s).

Lua experimental params (so you can tune in the field):
[0] = scale_p_yaw
[1] = scale_d_yaw
[2] = scale_p_collective
[3] = scale_d_collective
[4] = scale_collective_tau10

Tuning guide (generally you can start with normal D=0 and ignore `scale_d_*`):

0. The default values (80, 80, 70, 70, 20) should give a good starting point.
1. Hover and observe hard tail stops. Increase P gain (combined with D) and stop gains to achieve as good stop as possible. **Focus only on the stops**.
2. Pirouette **stationarily**, adjust `scale_p/d_yaw` accordingly (reduce if oscillate).
3. Do some full collective maneuvers (e.g., long pitch pump). **Ignore the transitions and keep collective full until lowpass charges up**. If tail oscillates, reduce `scale_p/d_collective`.
4. Do some fast collective change maneuvers. If tail oscillates during transition, add `tau`, if tail oscillates at the end of transitions, reduce `tau`.
5. Now you can fly freely for fun. If the tail oscillates in a specific maneuver, adjust conditionally:
    * If collective **and** yaw are centered: normal P/D gain and stop gains
    * If (abs) collective is high: `scale_p/d_collective`
    * If yaw is high: `scale_p/d_yaw`
    * If it's a common transition problem, redo step 4.
