### PR TITLE
feat: added save on disarm if armed in MSP_EEPROM_WRITE

### DIFF
--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -2782,6 +2782,7 @@ static mspResult_e mspProcessInCommand(mspDescriptor_t srcDesc, int16_t cmdMSP, 
 
     case MSP_EEPROM_WRITE:
         if (ARMING_FLAG(ARMED)) {
+            setConfigDirty();
             return MSP_RESULT_ERROR;
         }
 


### PR DESCRIPTION
Fix for automatically saving to eeprom on disarm if the heli is armed at the time of saving.