### PR TITLE
 ESC sensor: HW4 spike filtering

### DIFF
--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -1544,7 +1544,7 @@ const clivalue_t valueTable[] = {
     { "esc_sensor_hw4_current_gain",    VAR_UINT8   | MASTER_VALUE, .config.minmaxUnsigned = { 0, 250 }, PG_ESC_SENSOR_CONFIG, offsetof(escSensorConfig_t, hw4_current_gain) },
     { "esc_sensor_hw4_voltage_gain",    VAR_UINT8   | MASTER_VALUE, .config.minmaxUnsigned = { 0, 250 }, PG_ESC_SENSOR_CONFIG, offsetof(escSensorConfig_t, hw4_voltage_gain) },
     { "esc_sensor_filter_cutoff",       VAR_UINT8   | MASTER_VALUE, .config.minmaxUnsigned = { 0, 250 }, PG_ESC_SENSOR_CONFIG, offsetof(escSensorConfig_t, filter_cutoff) },
-    { "esc_sensor_hw4_filter_mode",     VAR_UINT8   | MASTER_VALUE, .config.minmaxUnsigned = { 0, 3 }, PG_ESC_SENSOR_CONFIG, offsetof(escSensorConfig_t, hw4_filter_mode) },
+    { "esc_sensor_hw4_filter_mode",     VAR_UINT8   | MASTER_VALUE, .config.minmaxUnsigned = { 1, 2 }, PG_ESC_SENSOR_CONFIG, offsetof(escSensorConfig_t, hw4_filter_mode) },
     { "esc_sensor_hw4_valid_current_readings_threshold",     VAR_UINT8   | MASTER_VALUE, .config.minmaxUnsigned = { 0, 254 }, PG_ESC_SENSOR_CONFIG, offsetof(escSensorConfig_t, hw4_valid_current_readings_threshold) },
 #endif
 

--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -1544,6 +1544,8 @@ const clivalue_t valueTable[] = {
     { "esc_sensor_hw4_current_gain",    VAR_UINT8   | MASTER_VALUE, .config.minmaxUnsigned = { 0, 250 }, PG_ESC_SENSOR_CONFIG, offsetof(escSensorConfig_t, hw4_current_gain) },
     { "esc_sensor_hw4_voltage_gain",    VAR_UINT8   | MASTER_VALUE, .config.minmaxUnsigned = { 0, 250 }, PG_ESC_SENSOR_CONFIG, offsetof(escSensorConfig_t, hw4_voltage_gain) },
     { "esc_sensor_filter_cutoff",       VAR_UINT8   | MASTER_VALUE, .config.minmaxUnsigned = { 0, 250 }, PG_ESC_SENSOR_CONFIG, offsetof(escSensorConfig_t, filter_cutoff) },
+    { "esc_sensor_hw4_filter_mode",     VAR_UINT8   | MASTER_VALUE, .config.minmaxUnsigned = { 0, 3 }, PG_ESC_SENSOR_CONFIG, offsetof(escSensorConfig_t, hw4_filter_mode) },
+    { "esc_sensor_hw4_valid_current_readings_threshold",     VAR_UINT8   | MASTER_VALUE, .config.minmaxUnsigned = { 0, 254 }, PG_ESC_SENSOR_CONFIG, offsetof(escSensorConfig_t, hw4_valid_current_readings_threshold) },
 #endif
 
 #ifdef USE_RX_FRSKY_SPI

--- a/src/main/common/filter.c
+++ b/src/main/common/filter.c
@@ -25,6 +25,7 @@
 #include "common/filter.h"
 #include "common/maths.h"
 #include "common/utils.h"
+#include "filter.h"
 
 
 static inline float limitCutoff(float cutoff, float sampleRate)
@@ -852,4 +853,22 @@ void simpleLPFilterInit(simpleLowpassFilter_t *filter, int32_t beta, int32_t fpS
     filter->fp = 0;
     filter->beta = beta;
     filter->fpShift = fpShift;
+}
+
+void simpleKalmanFilterInit(simpleKalmanFilter_t *filter, float x, float p, float q, float r)
+{
+    filter->x = x;
+    filter->p = p;
+    filter->q = q;
+    filter->r = r;
+}
+
+float simpleKalmanFilterUpdate(simpleKalmanFilter_t *filter, float z)
+{
+    filter->p += filter->q;
+    filter->k = filter->p / (filter->p + filter->r);
+    filter->x += filter->k * (z - filter->x);
+    filter->p *= (1 - filter->k);
+
+    return filter->x;
 }

--- a/src/main/common/filter.h
+++ b/src/main/common/filter.h
@@ -290,3 +290,14 @@ typedef struct simpleLowpassFilter_s {
 
 int32_t simpleLPFilterUpdate(simpleLowpassFilter_t *filter, int32_t newVal);
 void simpleLPFilterInit(simpleLowpassFilter_t *filter, int32_t beta, int32_t fpShift);
+
+typedef struct simpleKalmanFilter_s {
+    float x;  // Estimated value
+    float p;  // Estimated uncertainty
+    float q;  // Process noise
+    float r;  // Measurement noise
+    float k;  // Kalman gain
+} simpleKalmanFilter_t;
+
+void simpleKalmanFilterInit(simpleKalmanFilter_t *filter, float x, float p, float q, float r);
+float simpleKalmanFilterUpdate(simpleKalmanFilter_t *filter, float z);

--- a/src/main/pg/esc_sensor.c
+++ b/src/main/pg/esc_sensor.c
@@ -33,4 +33,6 @@ PG_RESET_TEMPLATE(escSensorConfig_t, escSensorConfig,
         .hw4_current_offset = 0,
         .hw4_current_gain = 0,
         .hw4_voltage_gain = 0,
+        .hw4_filter_mode = 2, // 1 = kalman, 2 = last readings > THRESHOLD
+        .hw4_valid_current_readings_threshold = 5,
 );

--- a/src/main/pg/esc_sensor.h
+++ b/src/main/pg/esc_sensor.h
@@ -52,6 +52,8 @@ typedef struct {
     uint8_t     hw4_current_gain;       // HobbyWing V4 current gain
     uint8_t     hw4_voltage_gain;       // HobbyWing V4 voltage gain
     uint8_t     filter_cutoff;          // Frequency cutoff in Hz
+    uint8_t     hw4_filter_mode;
+    uint8_t     hw4_valid_current_readings_threshold;
 } escSensorConfig_t;
 
 PG_DECLARE(escSensorConfig_t, escSensorConfig);

--- a/src/main/sensors/esc_sensor.c
+++ b/src/main/sensors/esc_sensor.c
@@ -127,7 +127,6 @@ static float totalConsumption = 0.0f;
 
 // HW4 filtering foo
 static simpleKalmanFilter_t hw4CurrentKalmanFilter;
-static uint32_t validReadingsCounterBeforeEnable = 0;
 
 static uint32_t totalByteCount = 0;
 static uint32_t totalFrameCount = 0;
@@ -645,18 +644,16 @@ static void hw4SensorProcess(timeUs_t currentTimeUs)
                     current = simpleKalmanFilterUpdate(&hw4CurrentKalmanFilter, current);
                 else if (escSensorConfig()->hw4_filter_mode == 2)
                 {
-                    if (validReadingsCounterBeforeEnable < escSensorConfig()->hw4_valid_current_readings_threshold)
+                    static uint32_t nonZeroReadingsCnt = 0;
+                    if (current != 0)
                     {
-                        if (current != 0)
+                        if (++nonZeroReadingsCnt <= escSensorConfig()->hw4_valid_current_readings_threshold)
                         {
-                            if (++validReadingsCounterBeforeEnable < escSensorConfig()->hw4_valid_current_readings_threshold)
-                            {
-                                current = 0;
-                            }
+                            current = 0;
                         }
-                        else
-                            validReadingsCounterBeforeEnable = 0;
                     }
+                    else
+                        nonZeroReadingsCnt = 0;
                 }
 
                 setConsumptionCurrent(current);

--- a/src/main/sensors/esc_sensor.c
+++ b/src/main/sensors/esc_sensor.c
@@ -32,6 +32,7 @@
 
 #include "common/time.h"
 #include "common/crc.h"
+#include "common/filter.h"
 
 #include "pg/pg.h"
 #include "pg/pg_ids.h"
@@ -123,6 +124,8 @@ static timeUs_t consumptionUpdateUs = 0;
 
 static float consumptionDelta = 0.0f;
 static float totalConsumption = 0.0f;
+
+simpleKalmanFilter_t hw4CurrentKalmanFilter;
 
 static uint32_t totalByteCount = 0;
 static uint32_t totalFrameCount = 0;
@@ -634,6 +637,8 @@ static void hw4SensorProcess(timeUs_t currentTimeUs)
                 if (pwm == 0) {
                     current = 0;
                 }
+
+                current = simpleKalmanFilterUpdate(&hw4CurrentKalmanFilter, current);
 
                 setConsumptionCurrent(current);
 
@@ -3415,6 +3420,7 @@ bool INIT_CODE escSensorInit(void)
             baudrate = 115200;
             break;
         case ESC_SENSOR_PROTO_HW4:
+            simpleKalmanFilterInit(&hw4CurrentKalmanFilter, 0, 0, 0.5, 5);
             baudrate = 19200;
             break;
         case ESC_SENSOR_PROTO_SCORPION:


### PR DESCRIPTION
The problem with HW4 is that, when there's no load on the head, the current readings have spikes in it. Eg. the current is 0 for a long period of time and suddenly a spike to 4A happens and then drops back to 0. I don't know whether the current readings have spikes when there's load on the head. However, the spikee current readings are apparently a problem and we should try getting rid of it.

There are 2  'filters' implemented
1 = kalman filter
2 = last X readings > 0, and only then consider the current reading valid, until a new 0 reading is seen, then this starts over

Another idea might be running average over the last X readings?
In general, I think the filtering should only be applied if current readings are below a certain threshold as otherwise consumption might be completely broken. 

Some testing: 
1: Smooths everything out and spikes are gone. Don't know the impact on the actual readings, might completely screw consumption etc
2: Is very dumb and the spikes are obviously not gone, just the 0 to e.g. 4A spikes. Spikes from e.g. 4 to e.g. 7 are still there

You can change the filter method via CLI:
kalman filter: set esc_sensor_hw4_filter_mode = 1
dumb 0 filter: set esc_sensor_hw4_filter_mode = 2

For the dumb 0 filter you can adjust the threshold via CLI
set esc_sensor_hw4_valid_current_readings_threshold = 5 (0-254)

Note: This is a draft version and I opened it for others to take a look, maybe test, and get comments on it. Code is not clean etc. 
Note2: I've no clue about filtering, kalman filters, whatsoever. I've no idea if the implemented kalman filter is correct, or the parameters are chosen appropriately.