### PR TITLE
Include ESC1 Status, ESC1 & ESC2 Model ID sensors in FrSky telemetry stream

### DIFF
--- a/src/main/telemetry/smartport.c
+++ b/src/main/telemetry/smartport.c
@@ -183,12 +183,15 @@ static telemetrySensor_t smartportTelemetrySensors[] =
     TLM_SENSOR(ESC1_TEMP2,              0x0419,   100,  3000,   1,  10,   10,   INT),
     TLM_SENSOR(ESC1_BEC_VOLTAGE,        0x0219,   100,  3000,   1,  10,   100,  INT),
     TLM_SENSOR(ESC1_BEC_CURRENT,        0x0229,   100,  3000,   1,  10,   0,    INT),
+    TLM_SENSOR(ESC1_STATUS,             0x512A,   200,  3000,   0,   0,   0,    INT),
+    TLM_SENSOR(ESC1_MODEL,              0x512B,   200,  3000,   0,   0,   0,    INT),
 
     TLM_SENSOR(ESC2_VOLTAGE,            0x021A,   100,  3000,   1,  10,   10,   INT),
     TLM_SENSOR(ESC2_CURRENT,            0x020A,   100,  3000,   1,  10,   100,  INT),
     TLM_SENSOR(ESC2_CAPACITY,           0x525A,   100,  3000,   1,  10,   0,    INT),
     TLM_SENSOR(ESC2_ERPM,               0x050A,   100,  3000,   1,  10,   0,    INT),
     TLM_SENSOR(ESC2_TEMP1,              0x041A,   100,  3000,   1,  10,   10,   INT),
+    TLM_SENSOR(ESC2_MODEL,              0x512C,   200,  3000,   0,   0,   0,    INT),
 
     TLM_SENSOR(MCU_VOLTAGE,             0x0900,   100,  3000,   1,  10,   10,   INT),
     TLM_SENSOR(BEC_VOLTAGE,             0x0901,   100,  3000,   1,  10,   10,   INT),


### PR DESCRIPTION
Included ESC1 Status, ESC1 & ESC2 Model ID sensors in FrSky telemetry stream for support of ESC status widget parity w/ ELRS telemetry
(previous PR closed in error)

Related PRs...
- https://github.com/rotorflight/rotorflight-lua-ethos-suite/pull/285
- https://github.com/rotorflight/rotorflight-configurator/pull/270

e.g.
![image](https://github.com/user-attachments/assets/27ae77b7-7f05-4a1a-9dd4-adfee49c1ddf)
![image](https://github.com/user-attachments/assets/eb756157-c3bf-4616-8fd2-11d903c73529)
