### PR TITLE
Xdfly hotfix

### DIFF
--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -477,7 +477,7 @@ const char * const lookupTableErrorRelaxType[] = {
 
 #ifdef USE_ESC_SENSOR
 static const char * const lookupTableEscSensorProtocol[] = {
-    "OFF", "BLHELI32", "HOBBYWINGV4", "HOBBYWINGV5", "SCORPION", "KONTRONIK", "OMPHOBBY", "ZTW", "APD", "OPENYGE", "FLYROTOR", "GRAUPNER", "RECORD",
+    "OFF", "BLHELI32", "HOBBYWINGV4", "HOBBYWINGV5", "SCORPION", "KONTRONIK", "OMPHOBBY", "ZTW", "APD", "OPENYGE", "FLYROTOR", "GRAUPNER", "XDFLY", "RECORD",
 };
 #endif
 

--- a/src/main/sensors/esc_sensor.c
+++ b/src/main/sensors/esc_sensor.c
@@ -3946,6 +3946,7 @@ void INIT_CODE validateAndFixEscSensorConfig(void)
 {
     switch (escSensorConfig()->protocol) {
         case ESC_SENSOR_PROTO_GRAUPNER:
+        case ESC_SENSOR_PROTO_XDFLY:
             escSensorConfigMutable()->halfDuplex = true;
             break;
 #ifdef USE_TELEMETRY_CASTLE

--- a/src/main/sensors/esc_sensor.c
+++ b/src/main/sensors/esc_sensor.c
@@ -3442,8 +3442,8 @@ static bool xdfly_connected = false;
 static bool xdfly_send_handshake = false;
 static bool xdfly_handshake_response_pending = false;
 static timeMs_t xdfly_handshake_timestamp = 0;
-static int xdfly_param_index = 0;
-static int xdfly_write_param_index = 0;
+static uint8_t xdfly_param_index = 0;
+static uint8_t xdfly_write_param_index = 0;
 
 static void xdfly_sensor_process(timeUs_t current_time_us)
 {
@@ -3490,7 +3490,7 @@ static void xdfly_sensor_process(timeUs_t current_time_us)
     checkFrameTimeout(current_time_us, 500000);
 }
 
-static void xdfly_build_req(uint8_t cmd, int *param_idx, uint16_t frame_period, uint16_t frame_timeout)
+static void xdfly_build_req(uint8_t cmd, uint8_t *param_idx, uint16_t frame_period, uint16_t frame_timeout)
 {
     uint8_t idx = 0;
 
@@ -3503,13 +3503,11 @@ static void xdfly_build_req(uint8_t cmd, int *param_idx, uint16_t frame_period, 
         reqbuffer[idx++] = 0;
         reqbuffer[idx++] = 0;
     } else if (cmd == XDFLY_CMD_GET_PARAM) {
-        memcpy(reqbuffer + idx, param_idx, XDFLY_PAYLOAD_LENGTH);
-        idx++;
+        reqbuffer[idx++] = *param_idx;
         reqbuffer[idx++] = 0;
         reqbuffer[idx++] = 0;
     } else if (cmd == XDFLY_CMD_SET_PARAM) {
-        memcpy(reqbuffer + idx, param_idx, XDFLY_PAYLOAD_LENGTH);
-        idx++;
+        reqbuffer[idx++] = *param_idx;
         reqbuffer[idx++] = paramUpdPayload[(*param_idx) * 2 + 1] | 0x80;
         reqbuffer[idx++] = paramUpdPayload[(*param_idx) * 2];
     }


### PR DESCRIPTION
- removed memcpy as suggested by @breavyn 
- added XDFLY to ESC sensor lookup table to allow dumping the XDFLY telemetry settings
- forcing half duplex when enabling XDFLY telem to prevent FW freeze due to TX buffer not being cleared