### PR TITLE
Correct xBusProvider switch flow in xBusDataReceive function. doesn't need to fallthrough

### DIFF
--- a/src/main/rx/xbus.c
+++ b/src/main/rx/xbus.c
@@ -326,7 +326,7 @@ static void xBusDataReceive(uint16_t c, void *data)
             break; // Changed to not fall through
         case SERIALRX_XBUS_MODE_A:
             xBusUnpackModeAFrame(XBUS_MODEA_OFFSET_BYTES);
-			break;
+            break;
         }
         xBusDataIncoming = false;
         xBusFramePosition = 0;

--- a/src/main/rx/xbus.c
+++ b/src/main/rx/xbus.c
@@ -320,12 +320,13 @@ static void xBusDataReceive(uint16_t c, void *data)
         switch (xBusProvider) {
         case SERIALRX_XBUS_MODE_B:
             xBusUnpackModeBFrame(0);
-            FALLTHROUGH; //!!TODO - check this fall through is correct
+            break; // Changed to not fall through
         case SERIALRX_XBUS_MODE_B_RJ01:
             xBusUnpackRJ01Frame();
-            FALLTHROUGH; //!!TODO - check this fall through is correct
+            break; // Changed to not fall through
         case SERIALRX_XBUS_MODE_A:
             xBusUnpackModeAFrame(XBUS_MODEA_OFFSET_BYTES);
+			break;
         }
         xBusDataIncoming = false;
         xBusFramePosition = 0;


### PR DESCRIPTION
Correct a flow issue that was  causing intermittent issues with XBus Mode B, as the code was falling through the switch statement to other switch statements. This was put in place by the original implementer of the XBus Mode B protocol back in 2014 and would have worked fine, until I added in the Mode A code and continued on.

Second part was correcting the spacing of the break statement on line 329