### PR TITLE
Debug: include SWO pin in the swdPinsInit()

### DIFF
--- a/src/main/fc/init.c
+++ b/src/main/fc/init.c
@@ -253,6 +253,10 @@ static void swdPinsInit(void)
     if (IOGetOwner(io) == OWNER_FREE) {
         IOInit(io, OWNER_SWD, 0);
     }
+    io = IOGetByTag(DEFIO_TAG_E(PB3)); // SWO
+    if (IOGetOwner(io) == OWNER_FREE) {
+        IOInit(io, OWNER_SWD, 0);
+    }
 }
 
 void init(void)


### PR DESCRIPTION
If not already occupied by the FC, this pin can be useful in SWD debugging. Claim it to SWD so it is not de-inited by `unusedPinsInit()`