### PR TITLE
Spektrum SRXL2 Rx, force half duplex in a way so RFC can see it.

### DIFF
--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -550,6 +550,7 @@ static void validateAndFixConfig(void)
     validateAndFixPositionConfig();
     validateAndFixServoConfig();
     validateAndFixMixerConfig();
+    validateAndFixRxConfig();
 }
 
 void validateAndFixGyroConfig(void)

--- a/src/main/rx/rx.c
+++ b/src/main/rx/rx.c
@@ -252,6 +252,25 @@ static bool serialRxInit(const rxConfig_t *rxConfig, rxRuntimeState_t *rxRuntime
 }
 #endif
 
+void validateAndFixRxConfig()
+{
+#ifdef USE_SERIAL_RX
+    if (featureIsEnabled(FEATURE_RX_SERIAL)) {
+
+      switch (rxConfig()->serialrx_provider) {
+#ifdef USE_SERIALRX_SRXL2
+      case SERIALRX_SRXL2:
+          validateAndFixSrxl2Config();
+          break;
+#endif
+      default:
+          break;
+      }
+    }
+#endif
+}
+
+
 void rxInit(void)
 {
     if (featureIsEnabled(FEATURE_RX_PARALLEL_PWM)) {

--- a/src/main/rx/rx.h
+++ b/src/main/rx/rx.h
@@ -180,6 +180,7 @@ extern linkQualitySource_e linkQualitySource;
 extern rxRuntimeState_t rxRuntimeState; //!!TODO remove this extern, only needed once for channelCount
 
 void rxInit(void);
+void validateAndFixRxConfig();
 void rxProcessPending(bool state);
 bool rxUpdateCheck(timeUs_t currentTimeUs, timeDelta_t currentDeltaTimeUs);
 void rxFrameCheck(timeUs_t currentTimeUs, timeDelta_t currentDeltaTimeUs);

--- a/src/main/rx/srxl2.c
+++ b/src/main/rx/srxl2.c
@@ -483,6 +483,9 @@ bool srxl2RxInit(const rxConfig_t *rxConfig, rxRuntimeState_t *rxRuntimeState)
         channelData[i] = SRXL2_CHANNEL_CENTER;
     }
 
+    // Force half duplex in a way so RFC can see it
+    rxConfigMutable()->halfDuplex = true;
+
     unitId = rxConfig->srxl2_unit_id;
     baudRate = rxConfig->srxl2_baud_fast;
 

--- a/src/main/rx/srxl2.c
+++ b/src/main/rx/srxl2.c
@@ -60,7 +60,7 @@
 
 #define SRXL2_PORT_BAUDRATE_DEFAULT    115200
 #define SRXL2_PORT_BAUDRATE_HIGH       400000
-#define SRXL2_PORT_OPTIONS             (SERIAL_STOPBITS_1 | SERIAL_PARITY_NO | SERIAL_BIDIR)
+#define SRXL2_PORT_OPTIONS             (SERIAL_STOPBITS_1 | SERIAL_PARITY_NO)
 #define SRXL2_PORT_MODE                MODE_RXTX
 
 #define SRXL2_REPLY_QUIESCENCE         (2 * 10 * 1000000 / SRXL2_PORT_BAUDRATE_DEFAULT) // 2 * (lastIdleTimestamp - lastReceiveTimestamp). Time taken to send 2 bytes

--- a/src/main/rx/srxl2.c
+++ b/src/main/rx/srxl2.c
@@ -476,15 +476,18 @@ void srxl2RxWriteData(const void *data, int len)
     writeBufferIdx = len;
 }
 
+void validateAndFixSrxl2Config()
+{
+    // Force half duplex
+    rxConfigMutable()->halfDuplex = true;
+}
+
 bool srxl2RxInit(const rxConfig_t *rxConfig, rxRuntimeState_t *rxRuntimeState)
 {
     static uint16_t channelData[SRXL2_MAX_CHANNELS];
     for (size_t i = 0; i < SRXL2_MAX_CHANNELS; ++i) {
         channelData[i] = SRXL2_CHANNEL_CENTER;
     }
-
-    // Force half duplex in a way so RFC can see it
-    rxConfigMutable()->halfDuplex = true;
 
     unitId = rxConfig->srxl2_unit_id;
     baudRate = rxConfig->srxl2_baud_fast;

--- a/src/main/rx/srxl2.h
+++ b/src/main/rx/srxl2.h
@@ -8,6 +8,7 @@
 
 struct sbuf_s;
 
+void validateAndFixSrxl2Config();
 bool srxl2RxInit(const rxConfig_t *rxConfig, rxRuntimeState_t *rxRuntimeState);
 bool srxl2RxIsActive(void);
 void srxl2RxWriteData(const void *data, int len);


### PR DESCRIPTION
Currently SRXL2 half duplex serial is forced by the driver but RFC does not show it. 