### PR TITLE
Scaling on Attidude sensors was out by a multiple of 10

### DIFF
--- a/src/main/telemetry/smartport.c
+++ b/src/main/telemetry/smartport.c
@@ -88,8 +88,8 @@ static void smartPortSensorEncodeINT(__unused telemetrySensor_t *sensor, smartPo
 
 static void smartPortSensorEncodeAttitude(__unused telemetrySensor_t *sensor, smartPortPayload_t *payload)
 {
-    const uint32_t roll = telemetrySensorValue(TELEM_ATTITUDE_ROLL) & 0xFFFF;
-    const uint32_t pitch = telemetrySensorValue(TELEM_ATTITUDE_PITCH) & 0xFFFF;
+    const uint32_t roll = telemetrySensorValue(TELEM_ATTITUDE_ROLL) * 10 & 0xFFFF;
+    const uint32_t pitch = telemetrySensorValue(TELEM_ATTITUDE_PITCH) * 10 & 0xFFFF;
 
     payload->data = roll | pitch << 16;
 }


### PR DESCRIPTION
This PR multiples out the sensor value by a multiple of 10.

Result was that we where getting 9 degrees when should have been 90 degrees.