### PR TITLE
Change default for  cbat_alert_percent  to 35%

### DIFF
--- a/src/main/pg/battery.c
+++ b/src/main/pg/battery.c
@@ -46,7 +46,7 @@ PG_RESET_TEMPLATE(batteryConfig_t, batteryConfig,
     .vbathysteresis = 1,
     .lvcPercentage = 100, // Off by default at 100%
     .batteryCapacity = 0,
-    .consumptionWarningPercentage = 10,
+    .consumptionWarningPercentage = 35,
     .useVoltageAlerts = true,
     .useConsumptionAlerts = false,
     .vbatDurationForWarning = 0,


### PR DESCRIPTION
This PR updates the default value for

set cbat_alert_percent

from 10  to 35

With the use of this setting becoming a used feature in suite; a more usefull and safe min pack threshold should be used.