### PR TITLE
feat: added flight statistics to MSP_FLIGHT_STATS

### DIFF
--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -1697,13 +1697,15 @@ const clivalue_t valueTable[] = {
 #ifdef USE_OSD
     { "display_name",     VAR_UINT8  | MASTER_VALUE | MODE_STRING, .config.string = { 1, MAX_NAME_LENGTH, STRING_FLAGS_NONE }, PG_PILOT_CONFIG, offsetof(pilotConfig_t, displayName) },
 #endif
-    { "model_id",         VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 0, 99 }, PG_PILOT_CONFIG, offsetof(pilotConfig_t, modelId) },
-    { "model_param1_type",  VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_PARAM_TYPE }, PG_PILOT_CONFIG, offsetof(pilotConfig_t, modelParam1Type) },
-    { "model_param1_value", VAR_INT16  | MASTER_VALUE, .config.minmax = { INT16_MIN, INT16_MAX }, PG_PILOT_CONFIG, offsetof(pilotConfig_t, modelParam1Value) },
-    { "model_param2_type",  VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_PARAM_TYPE }, PG_PILOT_CONFIG, offsetof(pilotConfig_t, modelParam2Type) },
-    { "model_param2_value", VAR_INT16  | MASTER_VALUE, .config.minmax = { INT16_MIN, INT16_MAX }, PG_PILOT_CONFIG, offsetof(pilotConfig_t, modelParam2Value) },
-    { "model_param3_type",  VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_PARAM_TYPE }, PG_PILOT_CONFIG, offsetof(pilotConfig_t, modelParam3Type) },
-    { "model_param3_value", VAR_INT16  | MASTER_VALUE, .config.minmax = { INT16_MIN, INT16_MAX }, PG_PILOT_CONFIG, offsetof(pilotConfig_t, modelParam3Value) },
+    { "model_id",             VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 0, 99 }, PG_PILOT_CONFIG, offsetof(pilotConfig_t, modelId) },
+    { "model_param1_type",    VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_PARAM_TYPE }, PG_PILOT_CONFIG, offsetof(pilotConfig_t, modelParam1Type) },
+    { "model_param1_value",   VAR_INT16  | MASTER_VALUE, .config.minmax = { INT16_MIN, INT16_MAX }, PG_PILOT_CONFIG, offsetof(pilotConfig_t, modelParam1Value) },
+    { "model_param2_type",    VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_PARAM_TYPE }, PG_PILOT_CONFIG, offsetof(pilotConfig_t, modelParam2Type) },
+    { "model_param2_value",   VAR_INT16  | MASTER_VALUE, .config.minmax = { INT16_MIN, INT16_MAX }, PG_PILOT_CONFIG, offsetof(pilotConfig_t, modelParam2Value) },
+    { "model_param3_type",    VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_PARAM_TYPE }, PG_PILOT_CONFIG, offsetof(pilotConfig_t, modelParam3Type) },
+    { "model_param3_value",   VAR_INT16  | MASTER_VALUE, .config.minmax = { INT16_MIN, INT16_MAX }, PG_PILOT_CONFIG, offsetof(pilotConfig_t, modelParam3Value) },
+    { "model_set_name",       VAR_UINT32 | MASTER_VALUE | MODE_BITSET, .config.bitpos = MODEL_SET_NAME, PG_PILOT_CONFIG, offsetof(pilotConfig_t, modelFlags) },
+    { "model_tell_capacity",  VAR_UINT32 | MASTER_VALUE | MODE_BITSET, .config.bitpos = MODEL_TELL_CAPACITY, PG_PILOT_CONFIG, offsetof(pilotConfig_t, modelFlags) },
 
 // PG_POSITION
     { "position_alt_source",       VAR_UINT8 | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_POSITION_ALT_SOURCE }, PG_POSITION, offsetof(positionConfig_t, alt_source) },

--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -1133,6 +1133,10 @@ static bool mspProcessOutCommand(int16_t cmdMSP, sbuf_t *dst)
         sbufWriteU16(dst, pilotConfig()->modelParam3Value);
         // Introduced in MSP API 12.9
         sbufWriteU32(dst, pilotConfig()->modelFlags);
+        break;
+
+    case MSP_FLIGHT_STATS:
+        // Introduced in MSP API 12.9
         sbufWriteU32(dst, statsConfig()->stats_total_flights);
         sbufWriteU32(dst, statsConfig()->stats_total_time_s);
         sbufWriteU32(dst, statsConfig()->stats_total_dist_m);
@@ -3382,14 +3386,18 @@ static mspResult_e mspProcessInCommand(mspDescriptor_t srcDesc, int16_t cmdMSP, 
         pilotConfigMutable()->modelParam2Value = sbufReadU16(src);
         pilotConfigMutable()->modelParam3Type = sbufReadU8(src);
         pilotConfigMutable()->modelParam3Value = sbufReadU16(src);
-        if (sbufBytesRemaining(src) >= 17) {
+        if (sbufBytesRemaining(src) >= 4) {
             // Introduced in MSP API 12.9
             pilotConfigMutable()->modelFlags = sbufReadU32(src);
-            statsConfigMutable()->stats_total_flights = sbufReadU32(src);
-            statsConfigMutable()->stats_total_time_s = sbufReadU32(src);
-            statsConfigMutable()->stats_total_dist_m = sbufReadU32(src);
-            statsConfigMutable()->stats_min_armed_time_s = sbufReadS8(src);
         }
+        break;
+
+    case MSP_SET_FLIGHT_STATS:
+        // Introduced in MSP API 12.9
+        statsConfigMutable()->stats_total_flights = sbufReadU32(src);
+        statsConfigMutable()->stats_total_time_s = sbufReadU32(src);
+        statsConfigMutable()->stats_total_dist_m = sbufReadU32(src);
+        statsConfigMutable()->stats_min_armed_time_s = sbufReadS8(src);
         break;
 
 #ifdef USE_RTC_TIME

--- a/src/main/msp/msp_protocol.h
+++ b/src/main/msp/msp_protocol.h
@@ -76,6 +76,8 @@
 #define MSP_SET_NAME                         11
 #define MSP_PILOT_CONFIG                     12
 #define MSP_SET_PILOT_CONFIG                 13
+#define MSP_FLIGHT_STATS                     14
+#define MSP_SET_FLIGHT_STATS                 15
 
 #define MSP_BATTERY_CONFIG                   32
 #define MSP_SET_BATTERY_CONFIG               33

--- a/src/main/pg/pilot.h
+++ b/src/main/pg/pilot.h
@@ -25,6 +25,12 @@
 
 #define MAX_NAME_LENGTH 16U
 
+enum {
+    // Model flags indicate what features on the radio should be enabled for this model.
+    MODEL_SET_NAME = 0,     // Set the name of the model on the radio
+    MODEL_TELL_CAPACITY     // Annouce the model battery capacity left on the radio
+};
+
 typedef struct {
     char    name[MAX_NAME_LENGTH + 1];
     char    displayName[MAX_NAME_LENGTH + 1];
@@ -35,6 +41,7 @@ typedef struct {
     int16_t modelParam2Value;
     uint8_t modelParam3Type;
     int16_t modelParam3Value;
+    uint32_t  modelFlags;
 } pilotConfig_t;
 
 PG_DECLARE(pilotConfig_t, pilotConfig);


### PR DESCRIPTION
The flight statistics were only accessible through CLI. This PR adds support for MSP by extending MSP_PILOT_CONFIG with those stats, so they can be used by e.g. [Lua](https://github.com/rotorflight/rotorflight-lua-scripts/pull/108):

![image](https://github.com/user-attachments/assets/ff8b6028-ffeb-45d0-aea4-34196b98824e)
 
Also added modelFlags to the pilotConfig_t structure, for model specific features, e.g. 'set name of model on the radio', or 'announce the battery capacity left'. 