### PR TITLE
Prevent calling flashEraseCompletely if async chip erase is not supported

### DIFF
--- a/src/main/drivers/flash.c
+++ b/src/main/drivers/flash.c
@@ -246,6 +246,11 @@ void flashEraseSector(uint32_t address)
     flashDevice.vTable->eraseSector(&flashDevice, address);
 }
 
+bool flashEraseCompletelySupported(void)
+{
+    return flashDevice.vTable->eraseCompletely != NULL;
+}
+
 void flashEraseCompletely(void)
 {
     flashDevice.callback = NULL;

--- a/src/main/drivers/flash.c
+++ b/src/main/drivers/flash.c
@@ -253,8 +253,10 @@ bool flashEraseCompletelySupported(void)
 
 void flashEraseCompletely(void)
 {
-    flashDevice.callback = NULL;
-    flashDevice.vTable->eraseCompletely(&flashDevice);
+    if (flashDevice.vTable->eraseCompletely) {
+        flashDevice.callback = NULL;
+        flashDevice.vTable->eraseCompletely(&flashDevice);
+    }
 }
 
 /* The callback, if provided, will receive the totoal number of bytes transfered

--- a/src/main/drivers/flash.h
+++ b/src/main/drivers/flash.h
@@ -53,6 +53,7 @@ bool flashInit(const flashConfig_t *flashConfig);
 bool flashIsReady(void);
 bool flashWaitForReady(void);
 void flashEraseSector(uint32_t address);
+bool flashEraseCompletelySupported(void);
 void flashEraseCompletely(void);
 void flashPageProgramBegin(uint32_t address, void (*callback)(uint32_t arg));
 uint32_t flashPageProgramContinue(const uint8_t **buffers, uint32_t *bufferSizes, uint32_t bufferCount);

--- a/src/main/drivers/flash_w25m.c
+++ b/src/main/drivers/flash_w25m.c
@@ -179,14 +179,6 @@ void w25m_eraseSector(flashDevice_t *fdevice, uint32_t address)
     dieDevice[dieNumber].vTable->eraseSector(&dieDevice[dieNumber], address % dieSize);
 }
 
-void w25m_eraseCompletely(flashDevice_t *fdevice)
-{
-    for (int dieNumber = 0 ; dieNumber < dieCount ; dieNumber++) {
-        w25m_dieSelect(fdevice->io.handle.dev, dieNumber);
-        dieDevice[dieNumber].vTable->eraseCompletely(&dieDevice[dieNumber]);
-    }
-}
-
 static uint32_t currentWriteAddress;
 static int currentWriteDie;
 
@@ -258,7 +250,7 @@ static const flashVTable_t w25m_vTable = {
     .isReady = w25m_isReady,
     .waitForReady = w25m_waitForReady,
     .eraseSector = w25m_eraseSector,
-    .eraseCompletely = w25m_eraseCompletely,
+    .eraseCompletely = NULL,
     .pageProgramBegin = w25m_pageProgramBegin,
     .pageProgramContinue = w25m_pageProgramContinue,
     .pageProgramFinish = w25m_pageProgramFinish,

--- a/src/main/drivers/flash_w25n.c
+++ b/src/main/drivers/flash_w25n.c
@@ -403,17 +403,6 @@ void w25n_eraseSector(flashDevice_t *fdevice, uint32_t address)
     w25n_setTimeout(fdevice, W25N_TIMEOUT_BLOCK_ERASE_MS);
 }
 
-//
-// W25N01G does not support full chip erase.
-// Call eraseSector repeatedly.
-
-void w25n_eraseCompletely(flashDevice_t *fdevice)
-{
-    for (uint32_t block = 0; block < fdevice->geometry.sectors; block++) {
-        w25n_eraseSector(fdevice, W25N_BLOCK_TO_LINEAR(block));
-    }
-}
-
 #ifndef W25N_NONBLOCKING_WRITE
 static void w25n_programDataLoad(flashDevice_t *fdevice, uint16_t columnAddress, const uint8_t *data, int length)
 {
@@ -979,7 +968,7 @@ const flashVTable_t w25n_vTable = {
     .isReady = w25n_isReady,
     .waitForReady = w25n_waitForReady,
     .eraseSector = w25n_eraseSector,
-    .eraseCompletely = w25n_eraseCompletely,
+    .eraseCompletely = NULL,
     .pageProgramBegin = w25n_pageProgramBegin,
     .pageProgramContinue = w25n_pageProgramContinue,
     .pageProgramFinish = w25n_pageProgramFinish,

--- a/src/main/io/flashfs.c
+++ b/src/main/io/flashfs.c
@@ -151,7 +151,11 @@ void flashfsEraseCompletely(void)
 {
     if (flashGeometry->sectors > 0 && flashPartitionCount() > 0) {
         // if there's a single FLASHFS partition and it uses the entire flash then do a full erase
-        const bool doFullErase = (flashPartitionCount() == 1) && (FLASH_PARTITION_SECTOR_COUNT(flashPartition) == flashGeometry->sectors);
+        const bool doFullErase =
+            (flashPartitionCount() == 1) &&
+            (FLASH_PARTITION_SECTOR_COUNT(flashPartition) == flashGeometry->sectors) &&
+            flashEraseCompletelySupported();
+
         if (doFullErase) {
             flashEraseCompletely();
         } else {


### PR DESCRIPTION
Some flash chips (w25n series) don't support async full chip erase. The current emulated function in the flash chip driver will just cause FC to block wait and hang.

The flashfs is already capable of doing asynchronous sector-by-sector full chip erase. This PR avoids using emulated full chip erase from the driver if the chip doesn't support it natively. 

w25m series is also marked as unsupported for code simplicity.

Tested on Nexus XR.