### PR TITLE
ZTW Fwd programing support

### DIFF
--- a/src/main/sensors/esc_sensor.c
+++ b/src/main/sensors/esc_sensor.c
@@ -3496,7 +3496,7 @@ static int8_t xdfly_accept(uint16_t c)
     return 0;
 }
 
-static serialReceiveCallbackPtr xdflySensorInitCommon(uint8_t sig)
+static serialReceiveCallbackPtr xdflySensorInit(uint8_t sig)
 {
     rrfsmCrank  = xdfly_crank_unc_setup;
     rrfsmDecode = xdfly_decode;
@@ -3505,10 +3505,6 @@ static serialReceiveCallbackPtr xdflySensorInitCommon(uint8_t sig)
     escSig = sig;
     return rrfsmDataReceive;
 }
-
-static serialReceiveCallbackPtr xdflySensorInit(void)      { return xdflySensorInitCommon(ESC_SIG_XDFLY); }
-static serialReceiveCallbackPtr ompAsXdflySensorInit(void) { return xdflySensorInitCommon(ESC_SIG_OMP); }
-static serialReceiveCallbackPtr ztwAsXdflySensorInit(void) { return xdflySensorInitCommon(ESC_SIG_ZTW); }
 
 /*
  * Raw Telemetry Data Recorder
@@ -3795,11 +3791,11 @@ bool INIT_CODE escSensorInit(void)
             options |= SERIAL_PARITY_EVEN;
             break;
         case ESC_SENSOR_PROTO_OMPHOBBY:
-            callback = ompAsXdflySensorInit();
+            callback = xdflySensorInit(ESC_SIG_OMP);
             baudrate = 115200;
             break;        
          case ESC_SENSOR_PROTO_ZTW:
-            callback = ztwAsXdflySensorInit();
+            callback = xdflySensorInit(ESC_SIG_ZTW);
             baudrate = 115200;
             break;    
         case ESC_SENSOR_PROTO_APD:
@@ -3822,7 +3818,7 @@ bool INIT_CODE escSensorInit(void)
             baudrate = 19200;
             break;
         case ESC_SENSOR_PROTO_XDFLY:
-            callback = xdflySensorInit();
+            callback = xdflySensorInit(ESC_SIG_XDFLY);
             baudrate = 115200;
             break;
         case ESC_SENSOR_PROTO_RECORD:


### PR DESCRIPTION
This PR relies on the preceeding PR

https://github.com/rotorflight/rotorflight-firmware/pull/347

Support is added to include ZTW fwd programing and configuration.   

**Tested and working in legacy mode without a firmware that supports fwd programing**
<img width="1775" height="742" alt="ztw-legacy mode works" src="https://github.com/user-attachments/assets/8b8651d5-fce6-49ff-a9ce-2797171018be" />


Tested with old firmware and new firmwared.  All works as expected.


