### PR TITLE
Spektrum ESC telemetry output to Tx added. 

### DIFF
--- a/src/main/telemetry/srxl.c
+++ b/src/main/telemetry/srxl.c
@@ -456,7 +456,9 @@ bool srxlFrameFlightPackCurrent(sbuf_t *dst, timeUs_t currentTimeUs)
     return false;
 }
 
-//  ****** ESC Telem*try frame ******
+#ifdef USE_ESC_SENSOR_TELEMETRY
+
+//  ****** ESC Telemetry frame ******
 //
 //	Uses big-endian byte order
 //
@@ -547,7 +549,7 @@ bool srxlFrameEsc(sbuf_t *dst, timeUs_t currentTimeUs)
     }
     return false;
 }
-
+#endif
 
 
 
@@ -765,7 +767,12 @@ static bool srxlFrameVTX(sbuf_t *dst, timeUs_t currentTimeUs)
 #define SRXL_SCHEDULE_MANDATORY_COUNT  2 // Mandatory QOS and RPM sensors
 
 #define SRXL_FP_MAH_COUNT   1
+
+#ifdef USE_ESC_SENSOR_TELEMETRY
 #define SRXL_ESC_COUNT   1
+#else
+#define SRXL_ESC_COUNT   0
+#endif
 
 #if defined(USE_GPS)
 #define SRXL_GPS_LOC_COUNT  1
@@ -798,7 +805,9 @@ const srxlScheduleFnPtr srxlScheduleFuncs[SRXL_TOTAL_COUNT] = {
     srxlFrameQos,
     srxlFrameRpm,
     srxlFrameFlightPackCurrent,
+#ifdef USE_ESC_SENSOR_TELEMETRY
     srxlFrameEsc,
+#endif
 #if defined(USE_GPS)
     srxlFrameGpsStat,
     srxlFrameGpsLoc,


### PR DESCRIPTION
If some ESC telemetry sensor is enabled, it would be nice to have it shown on Tx as ESC telemetry. Even though most or all data elements already show up on other tlm pages, a collected view would be nice. 
Tested with hardcoded test data (screenshot below), and SDfly Hpro65 ESC, iX20, Nexus, SPM4650.  Spektrum has a problem in their end, shows BEC Amps (A) not mA.
 
![Screenshot_2025-12-16_125621](https://github.com/user-attachments/assets/02a63696-706e-4d31-93ed-5de133d01331)

Mininal radio extra bandwith wasted.
![Screenshot_2025-12-16_130803](https://github.com/user-attachments/assets/fe1ee8f4-b027-435a-bee8-ad0661330ad1)
/A 
