### PR TITLE
MSP: Add single-index read support to MSP_MIXER_INPUTS to reduce over-air payload size

### DIFF
--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -2090,7 +2090,7 @@ static mspResult_e mspFcProcessOutCommandWithArg(mspDescriptor_t srcDesc, int16_
             serializeBoxReply(dst, page, &serializeBoxPermanentIdFn);
         }
         break;
-    case MSP_MIXER_INPUTS_INDEXED:
+    case MSP_GET_MIXER_INPUT:
         {
             const int rem = sbufBytesRemaining(src);
             if (rem != 1) {

--- a/src/main/msp/msp_protocol.h
+++ b/src/main/msp/msp_protocol.h
@@ -212,7 +212,7 @@
 #define MSP_SET_MIXER_INPUT                  171
 #define MSP_MIXER_RULES                      172
 #define MSP_SET_MIXER_RULE                   173
-#define MSP_MIXER_INPUTS_INDEXED             174
+#define MSP_GET_MIXER_INPUT                  174
 
 #define MSP_OSD_VIDEO_CONFIG                 180
 #define MSP_SET_OSD_VIDEO_CONFIG             181


### PR DESCRIPTION

**Summary**
MSP_MIXER_INPUTS currently always returns the full mixer input table, which can result in large MSP payloads and timeouts when MSP is transported over low-bandwidth or high-latency links (for example over telemetry / RF links).

This change adds a backward-compatible single-index read mode to MSP_MIXER_INPUTS:

No request payload: existing behaviour, returns the full mixer input table

1-byte request payload (index): returns only the selected mixer input (rate, min, max)

This allows clients to read mixer inputs incrementally and significantly reduce MSP transfer size, while remaining fully compatible with existing tools.

**Details**

Implemented in mspFcProcessOutCommandWithArg()

Reuses existing MSP_MIXER_INPUTS command ID

Validates request payload size and index range

No changes to the legacy mspProcessOutCommand() path

**Request / Response formats**

_Legacy mode_
Request payload: none
Response payload: MIXER_INPUT_COUNT × (u16 rate, u16 min, u16 max)

_Indexed mode_
Request payload: u8 index
Response payload: u16 rate, u16 min, u16 max

**Motivation**
Over-air MSP links are sensitive to payload size. Large “read all” responses frequently cause retries or timeouts. Supporting indexed reads enables smaller MSP frames, faster UI response, and selective loading in configurators.

**Compatibility**

Fully backward compatible

Existing configurators continue to work unchanged

New clients may opt in to indexed reads