### PR TITLE
Add MSP call for handling just the trim in servo override mode

### DIFF
--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -2616,7 +2616,7 @@ static mspResult_e mspProcessInCommand(mspDescriptor_t srcDesc, int16_t cmdMSP, 
         setServoOverride(i, sbufReadU16(src));
         break;
 
-    case MSP_SET_SERVO_MID:
+    case MSP_SET_SERVO_CENTER:
         // payload: U8 idx + U16 mid  => 3 bytes
         if (dataSize != 1 + 2) {
             return MSP_RESULT_ERROR;

--- a/src/main/msp/msp_protocol.h
+++ b/src/main/msp/msp_protocol.h
@@ -242,7 +242,7 @@
 #define MSP_SELECT_SETTING                   210
 #define MSP_SET_HEADING                      211
 #define MSP_SET_SERVO_CONFIGURATION          212
-#define MSP_SET_SERVO_MID                    213
+#define MSP_SET_SERVO_CENTER                 213
 
 #define MSP_SET_MOTOR                        214
 #define MSP_SET_NAV_CONFIG                   215


### PR DESCRIPTION
This light weight trim call results in a far smoother trim action as payload is smaller.

The result is updating servo trim from lua script can run at around every 0.1s vs 0.8s with using the full save with all other parameters.

Related suite PR
https://github.com/rotorflight/rotorflight-lua-ethos-suite/pull/1595

Demo of use.
https://github.com/user-attachments/assets/ff7f5c31-c792-4bed-b153-4b3c08bbf97c

