### PR TITLE
Generic MSP access to CLI settings (name-based GET/SET)

### DIFF
--- a/src/main/cli/cli.h
+++ b/src/main/cli/cli.h
@@ -30,6 +30,12 @@ struct serialPort_s;
 void cliEnter(struct serialPort_s *serialPort);
 bool resetConfigToCustomDefaults(void);
 
+// MSP generic setting access (name-based)
+// Returns false if the setting is not found or unsupported (arrays/strings/etc).
+// value/min/max are returned as scaled integers; scalePow10 currently always 0 in this codebase.
+bool cliMspGetSettingByName(const char *name, int32_t *value, int32_t *min, int32_t *max, uint8_t *mspType, uint8_t *flags, int8_t *scalePow10);
+bool cliMspSetSettingByName(const char *name, int32_t value);
+
 #ifdef USE_CLI_DEBUG_PRINT
 void cliPrint(const char *str);
 void cliPrintLinefeed(void);

--- a/src/main/msp/msp_protocol.h
+++ b/src/main/msp/msp_protocol.h
@@ -62,6 +62,13 @@
 #define BOARD_IDENTIFIER_LENGTH              4
 #define BOARD_HARDWARE_REVISION_LENGTH       2
 
+// MSP setting value type for MSP_CLI_SETTING/MSP_SET_CLI_SETTING
+#define MSP_SETTING_TYPE_UINT8              0
+#define MSP_SETTING_TYPE_INT8               1
+#define MSP_SETTING_TYPE_UINT16             2
+#define MSP_SETTING_TYPE_INT16              3
+#define MSP_SETTING_TYPE_UINT32             4
+
 /*
  * MSP Command IDs
  */
@@ -228,6 +235,9 @@
 #define MSP_SET_SERVO_OVERRIDE               193
 #define MSP_MOTOR_OVERRIDE                   194
 #define MSP_SET_MOTOR_OVERRIDE               195
+
+#define MSP_CLI_SETTING                      196
+#define MSP_SET_CLI_SETTING                  197
 
 #define MSP_SET_RAW_RC                       200
 #define MSP_SET_RAW_GPS                      201


### PR DESCRIPTION
## Summary

This PR adds **generic, name-based MSP commands** to Rotorflight that allow external clients
(Lua radios, configurators, tools) to **read and write existing CLI `set` parameters**
without requiring a dedicated MSP command per setting.

The implementation reuses Rotorflight’s existing **CLI settings table** and enforces
the same validation and safety rules already applied by the CLI.

Two new MSP commands are introduced:

- `MSP_CLI_SETTING` – read any CLI setting by name
- `MSP_SET_CLI_SETTING` – write any CLI setting by name

This enables simple access to configuration values (e.g. governor mode, filters, limits)
from modern UIs without expanding the MSP surface area for each new parameter.

---

## Motivation (Rotorflight-specific)

Rotorflight exposes a rich and evolving configuration set via the CLI.  
UI clients (notably Lua-based radios) often need access to **individual parameters**
for setup and tuning, but today must rely on:

- large structured MSP APIs
- bespoke MSP commands
- or text-based CLI parsing (fragile and unsafe)

This PR provides a **small, explicit, binary MSP interface** that:

- maps directly to existing CLI `set` variables
- avoids adding new MSP commands as Rotorflight evolves
- avoids executing or parsing CLI text
- remains forward-compatible with future settings

Any existing Rotorflight CLI `set` parameter automatically becomes accessible over MSP.

---

## MSP Protocol

### MSP IDs

Uses reserved MSP IDs explicitly intended for extensions:

- `MSP_CLI_SETTING` = (196)
- `MSP_SET_CLI_SETTING` = (197)

---

### MSP_GET_SETTING

**Request**
```
u8  nameLen
u8  name[nameLen]   // ASCII, not null-terminated
```

**Reply**
```
u8   type           // MSP_SETTING_TYPE_*
u32  value          // signed value transported as u32 bit-pattern
u32  min
u32  max
u8   scalePow10     // currently 0 (reserved for future use)
u8   flags          // currently 0 (reserved for future use)
```

Notes:
- Values are returned in **Rotorflight CLI units**.
- `min` / `max` reflect CLI-defined limits or lookup table bounds.

---

### MSP_SET_SETTING

**Request**
```
u8  nameLen
u8  name[nameLen]
u32 value           // signed value transported as u32 bit-pattern
```

**Reply**
```
u8 success          // 1 = OK, 0 = failed
```

---

## Supported setting types

- Scalar numeric values (`u8`, `s8`, `u16`, `s16`, `u32`)
- Lookup / enum values
- Bitset values (boolean semantics)

### Not supported (by design)

- Arrays
- Strings
- Commands or side-effect operations

Unsupported types return an MSP error.

---

## Safety considerations

- **Writes are rejected while armed**
- Values are **clamped to CLI-defined min/max**
- EEPROM is **not written automatically**
  - Persisting changes remains an explicit action (`MSP_EEPROM_WRITE`)
- No CLI command execution is exposed

This mirrors Rotorflight’s existing CLI safety model.

---

## Implementation notes

- Settings are resolved via an **exact name match** against the CLI value table
- Read/write logic reuses existing Rotorflight CLI helpers and metadata
- No configuration duplication or shadow tables are introduced
- Zero impact on existing MSP commands and payloads

---

## Backward compatibility

- Fully backward compatible
- No changes to existing MSP APIs
- Uses reserved MSP IDs only

---

## Intended usage

This API is intended for:

- Rotorflight Lua-based radios (e.g. Ethos / EdgeTX integrations)
- Lightweight configuration tools
- Advanced UI workflows (read–modify–write, batching, deferred save)

Example use cases:
- Read and set `gov_mode`
- Toggle feature flags
- Adjust filters and limits
- Build dynamic UIs without firmware changes

---

## Future extensions (not included)

- Optional string / array support
- Exposing lookup table labels over MSP
- Scale factor support (`scalePow10` already reserved)
- Read-only / reboot-required flags

These can be added without breaking the protocol.

---

## Testing

Manually verified on Rotorflight:  

Tested via rfsuite using this matching api:
https://github.com/rotorflight/rotorflight-lua-ethos-suite/pull/1598/changes#diff-bfcc457a2e72f2732c590bac42cc1c8749f08c95734b729bba70e56f293a334e

- Reading scalar, lookup, and bitset CLI settings
- Writing valid and out-of-range values
- Write rejection while armed
- EEPROM persistence via existing mechanisms

---

## Rationale

This approach provides **maximum flexibility with minimal protocol surface**,
aligns MSP access with Rotorflight’s authoritative CLI configuration model,
and avoids long-term MSP fragmentation.
