### PR TITLE
Disallow arming when rescue is active

### DIFF
--- a/src/main/fc/core.c
+++ b/src/main/fc/core.c
@@ -318,6 +318,12 @@ void updateArmingStatus(void)
         }
 #endif
 
+        if (IS_RC_MODE_ACTIVE(BOXRESCUE)) {
+            setArmingDisabled(ARMING_DISABLED_RESC);
+        } else {
+            unsetArmingDisabled(ARMING_DISABLED_RESC);
+        }
+
 #ifdef USE_DSHOT_BITBANG
         if (isDshotBitbangActive(&motorConfig()->dev) && dshotBitbangGetStatus() != DSHOT_BITBANG_STATUS_OK) {
             setArmingDisabled(ARMING_DISABLED_DSHOT_BITBANG);


### PR DESCRIPTION
- The swashplate does the wiggle - if enabled - when rescue is active and the FC is armed
- The Configurator shows RESC in Arming Disable Flags