### PR TITLE
fixed detault setting for FBUS master

### DIFF
--- a/src/main/pg/fbus_master.c
+++ b/src/main/pg/fbus_master.c
@@ -38,7 +38,7 @@ void pgResetFn_fbusMasterConfig(fbusMasterConfig_t *config) {
     config->pinSwap = 0;
 
     // Default to inverted F.Bus (normal for F.Bus receivers).
-    config->inverted = SERIAL_INVERTED;
+    config->inverted = 1;
 }
 
 #endif


### PR DESCRIPTION
<img width="1072" height="568" alt="image" src="https://github.com/user-attachments/assets/ec54426f-d4b6-439d-bec4-4bfbce4dfff1" />
Due to an invalid default setting, we need to update the default settings for the FBUS master.