### PR TITLE
Vibration sensor (POC)

### DIFF
--- a/src/main/telemetry/crsf.c
+++ b/src/main/telemetry/crsf.c
@@ -824,6 +824,11 @@ static telemetrySensor_t crsfCustomTelemetrySensors[] =
 
     TLM_SENSOR(ADJFUNC,                 0x1220,   200,  3000,    0,     AdjFunc),
 
+    TLM_SENSOR(VIBE,                    0x1160,   200,  3000,    0,     U16),
+    TLM_SENSOR(VIBE_ROLL,               0x1161,   200,  3000,    0,     U16),
+    TLM_SENSOR(VIBE_PITCH,              0x1162,   200,  3000,    0,     U16),
+    TLM_SENSOR(VIBE_YAW,                0x1163,   200,  3000,    0,     U16),    
+
     TLM_SENSOR(DEBUG_0,                 0xDB00,   100,  3000,    0,     S32),
     TLM_SENSOR(DEBUG_1,                 0xDB01,   100,  3000,    0,     S32),
     TLM_SENSOR(DEBUG_2,                 0xDB02,   100,  3000,    0,     S32),

--- a/src/main/telemetry/sensors.h
+++ b/src/main/telemetry/sensors.h
@@ -165,6 +165,11 @@ typedef enum
     TELEM_RPM                           = 108,
     TELEM_TEMP                          = 109,
 
+    TELEM_VIBE                          = 110,
+    TELEM_VIBE_ROLL                     = 111,
+    TELEM_VIBE_PITCH                    = 112,
+    TELEM_VIBE_YAW                      = 113,
+
     TELEM_SENSOR_COUNT
 
 } sensor_id_e;

--- a/src/main/telemetry/smartport.c
+++ b/src/main/telemetry/smartport.c
@@ -242,6 +242,11 @@ static telemetrySensor_t smartportTelemetrySensors[] =
     TLM_SENSOR(ADJFUNC,                 0x5110,   200,  3000,   1,   1,   0,    AdjFunc),
     TLM_SENSOR(ADJFUNC,                 0x5111,   200,  3000,   1,   1,   0,    AdjValue),
 
+    TLM_SENSOR(VIBE,                    0x5142,   200,  3000,   1,  10,   0,    INT),
+    TLM_SENSOR(VIBE_ROLL,               0x5143,   200,  3000,   1,  10,   0,    INT),
+    TLM_SENSOR(VIBE_PITCH,              0x5144,   200,  3000,   1,  10,   0,    INT),
+    TLM_SENSOR(VIBE_YAW,                0x5145,   200,  3000,   1,  10,   0,    INT),
+
     TLM_SENSOR(DEBUG_0,                 0x52F0,   100,  3000,   1,  10,   0,    INT),
     TLM_SENSOR(DEBUG_1,                 0x52F1,   100,  3000,   1,  10,   0,    INT),
     TLM_SENSOR(DEBUG_2,                 0x52F2,   100,  3000,   1,  10,   0,    INT),


### PR DESCRIPTION
This is a proof of concept vibration analysis sensor.

The intention is a lightweight, always-available "gyro noise" indicator that can be exported as real telemetry sensors (ELRS custom telemetry, Frsky etc).

**Implementation notes:**
1. We use the difference between raw (scaled) gyroADC and filtered gyroADCf as a proxy for high-frequency energy removed by the filter chain.
2. We apply a simple EMA so the value is stable at typical telemetry rates.
3. Units are "(deg/s) * 10" (deci-deg/s) to keep integer telemetry encoding.

**Lua side**
https://github.com/rotorflight/rotorflight-lua-ethos-suite/pull/1643

**Example use**
https://github.com/user-attachments/assets/6c95e731-b38e-4c52-b543-92431bb7dddb

**Future enhancements**
Develop a lua side graph that shows an in-flight analisis of the vibration.

