### PR TITLE
fix: removed unused MSP_GOVERNOR_CONFIG parameters

### DIFF
--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -2041,8 +2041,6 @@ static bool mspProcessOutCommand(int16_t cmdMSP, sbuf_t *dst)
         sbufWriteU8(dst, governorConfig()->gov_d_filter);
         sbufWriteU16(dst, governorConfig()->gov_spooldown_time);
         sbufWriteU8(dst, governorConfig()->gov_throttle_type);
-        sbufWriteS8(dst, 0);
-        sbufWriteS8(dst, 0);
         sbufWriteU8(dst, governorConfig()->gov_idle_throttle);
         sbufWriteU8(dst, governorConfig()->gov_auto_throttle);
         for (int i=0; i<GOV_THROTTLE_CURVE_POINTS; i++)
@@ -3645,12 +3643,10 @@ static mspResult_e mspProcessInCommand(mspDescriptor_t srcDesc, int16_t cmdMSP, 
         if (sbufBytesRemaining(src) >= 1) {
             sbufReadU8(src); // governorConfigMutable()->gov_spoolup_min_throttle
         }
-        if (sbufBytesRemaining(src) >= 8) {
+        if (sbufBytesRemaining(src) >= 6) {
             governorConfigMutable()->gov_d_filter = sbufReadU8(src);
             governorConfigMutable()->gov_spooldown_time = sbufReadU16(src);
             governorConfigMutable()->gov_throttle_type = sbufReadU8(src);
-            sbufReadS8(src);
-            sbufReadS8(src);
             governorConfigMutable()->gov_idle_throttle = sbufReadU8(src);
             governorConfigMutable()->gov_auto_throttle = sbufReadU8(src);
         }


### PR DESCRIPTION
Removed two unused parameters from MSP 12.9 that were added in a previous version of 12.9 (gov_idle_collective and gov_wot_collective). 

We should maintain compatibility with previous releases (i.e. 4.5.1), not with any previous snapshots (e.g. 20251111).