### PR TITLE
fix: start tail motor asap

### DIFF
--- a/src/main/flight/mixer.c
+++ b/src/main/flight/mixer.c
@@ -372,12 +372,10 @@ static void mixerUpdateMotorizedTail(void)
         // Apply minimum throttle
         throttle = fmaxf(throttle, mixer.tailMotorIdle);
 
-        // Slow spoolup
+        // Start tail motor asap
         if (!isSpooledUp()) {
-            if (mixer.input[MIXER_IN_STABILIZED_THROTTLE] < 0.05f)
+            if (mixer.input[MIXER_IN_STABILIZED_THROTTLE] < 0.001f)
                 throttle = 0;
-            else if (mixer.input[MIXER_IN_STABILIZED_THROTTLE] < 0.10f)
-                throttle *= mixer.input[MIXER_IN_STABILIZED_THROTTLE] / 0.10f;
         }
 
         // Yaw is now tail motor throttle


### PR DESCRIPTION
This PR will start a tail motor as soon as possible, instead of waiting for the stabilized throttle to become bigger than 5%. It will help mitigate the initial kick on motorized tails. 