### PR TITLE
Fix Spektrum telemetry CMS, do not transmit unchanged text lines. 

### DIFF
--- a/src/main/telemetry/srxl.c
+++ b/src/main/telemetry/srxl.c
@@ -612,12 +612,14 @@ bool srxlFrameText(sbuf_t *dst, timeUs_t currentTimeUs)
         lineCount++;
     }
 
-    // On timeout, force redraw of all rowss
-    if (keepAlive > TEXT_KEEPALIVE_TIME_OUT) {
-      for (int i = 0; i < SPEKTRUM_SRXL_TEXTGEN_ROWS; i++) lineSent[i] = false;
-    }
+    if ( !(cmsInMenu && (pCurrentDisplay == &srxlDisplayPort)) ) {
+      // On timeout, force redraw of all rowss
+      if (keepAlive > TEXT_KEEPALIVE_TIME_OUT) {
+        for (int i = 0; i < SPEKTRUM_SRXL_TEXTGEN_ROWS; i++) lineSent[i] = false;
+      }
 
-    if (lineSent[lineNo]) return false;
+      if (lineSent[lineNo]) return false;
+    }
 
     sbufWriteU8(dst, SPEKTRUM_SRXL_DEVICE_TEXTGEN);
     sbufWriteU8(dst, SRXL_FRAMETYPE_SID);


### PR DESCRIPTION
Saves precious bandwidth for more important telemetry items.
Spektrum telemetry bandwidth is very limited, one 16 byte packet after each 11/22mS control packet. 
/A 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added a keep‑alive for telemetry text frames to prevent redundant transmissions and ensure periodic redraws (avoids stale displays). The mechanism respects menu conditions that suppress redraws, maintains per-line send tracking so already-sent lines aren’t re-sent unnecessarily, advances displayed lines after send, and applies the same behavior to the CMS text flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->