### PR TITLE
Disallow arming if override is active

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -353,6 +353,12 @@ completes. The existing CLI parameters are unchanged.
 Minor changes introduced to all three presets for better match to common
 use cases.
 
+### Servo/Mixer Override disables arming (#431)
+
+A new arming disabled flag `OVERRIDE` was added. It is activated if either
+servo or motor override is active.
+
+
 ## Receiver Protocols
 
 ### IBUS 2 Support (#424)

--- a/Changes.md
+++ b/Changes.md
@@ -356,7 +356,7 @@ use cases.
 ### Servo/Mixer Override disables arming (#431)
 
 A new arming disabled flag `OVERRIDE` was added. It is activated if either
-servo or motor override is active.
+servo or mixer override is active.
 
 
 ## Receiver Protocols

--- a/src/main/fc/core.c
+++ b/src/main/fc/core.c
@@ -348,6 +348,12 @@ void updateArmingStatus(void)
             setArmingDisabled(ARMING_DISABLED_MOTOR_PROTOCOL);
         }
 
+        if (isServoOverrideActive() || isMixerOverrideActive()) {
+            setArmingDisabled(ARMING_DISABLED_OVERRIDE);
+        } else {
+            unsetArmingDisabled(ARMING_DISABLED_OVERRIDE);
+        }
+
         if (!isUsingSticksForArming()) {
             /* Ignore ARMING_DISABLED_CALIBRATING if we are going to calibrate gyro on first arm */
             bool ignoreGyro = armingConfig()->gyro_cal_on_first_arm

--- a/src/main/fc/runtime_config.c
+++ b/src/main/fc/runtime_config.c
@@ -59,6 +59,7 @@ const char *armingDisableFlagNames[]= {
     "DSHOT_BBANG",
     "NO_ACC_CAL",
     "MOTOR_PROTO",
+    "OVERRIDE",
     "ARMSWITCH",
 };
 

--- a/src/main/fc/runtime_config.h
+++ b/src/main/fc/runtime_config.h
@@ -65,7 +65,8 @@ typedef enum {
     ARMING_DISABLED_DSHOT_BITBANG   = (1 << 22),
     ARMING_DISABLED_ACC_CALIBRATION = (1 << 23),
     ARMING_DISABLED_MOTOR_PROTOCOL  = (1 << 24),
-    ARMING_DISABLED_ARM_SWITCH      = (1 << 25), // Needs to be the last element, since it's always activated if one of the others is active when arming
+    ARMING_DISABLED_OVERRIDE        = (1 << 25),
+    ARMING_DISABLED_ARM_SWITCH      = (1 << 26), // Needs to be the last element, since it's always activated if one of the others is active when arming
 } armingDisableFlags_e;
 
 #define ARMING_DISABLE_FLAGS_COUNT (LOG2(ARMING_DISABLED_ARM_SWITCH) + 1)

--- a/src/main/flight/mixer.c
+++ b/src/main/flight/mixer.c
@@ -162,6 +162,16 @@ int16_t mixerSetOverride(uint8_t index, int16_t value)
     return mixer.override[index] = value;
 }
 
+bool isMixerOverrideActive(void)
+{
+    for (int i = 1; i < MIXER_INPUT_COUNT; i++) {
+        const int16_t ovr = mixer.override[i];
+        if ((ovr >= MIXER_OVERRIDE_MIN && ovr <= MIXER_OVERRIDE_MAX) || ovr == MIXER_OVERRIDE_PASSTHROUGH)
+            return true;
+    }
+    return false;
+}
+
 bool mixerIsCyclicServo(uint8_t index)
 {
     return (mixer.cyclicMapping & BIT(MIXER_SERVO_OFFSET + index));

--- a/src/main/flight/mixer.h
+++ b/src/main/flight/mixer.h
@@ -77,6 +77,7 @@ void mixerSaturateOutput(uint8_t index);
 
 int16_t mixerGetOverride(uint8_t index);
 int16_t mixerSetOverride(uint8_t index, int16_t value);
+bool    isMixerOverrideActive(void);
 
 bool mixerIsCyclicServo(uint8_t index);
 

--- a/src/main/flight/servos.c
+++ b/src/main/flight/servos.c
@@ -95,6 +95,15 @@ int16_t setServoOverride(uint8_t servo, int16_t val)
     return servoOverride[servo] = val;
 }
 
+bool isServoOverrideActive(void)
+{
+    for (int i = 0; i < MAX_SUPPORTED_SERVOS; i++) {
+        if (hasServoOverride(i))
+            return true;
+    }
+    return false;
+}
+
 void validateAndFixServoConfig(void)
 {
     for (int i = 0; i < MAX_SUPPORTED_SERVOS; i++) {

--- a/src/main/flight/servos.h
+++ b/src/main/flight/servos.h
@@ -59,6 +59,7 @@ uint16_t getServoOutput(uint8_t servo);
 int16_t getServoOverride(uint8_t servo);
 int16_t setServoOverride(uint8_t servo, int16_t val);
 bool    hasServoOverride(uint8_t servo);
+bool    isServoOverrideActive(void);
 
 #ifdef USE_SERVO_GEOMETRY_CORRECTION
 float geometryCorrection(float pos);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * System now monitors servo and mixer override engagement and automatically disables arming when either override is active, preventing accidental motor start.
  * UI/status reports include an explicit "Override" arming-disabled state so users can see when overrides are blocking arming.

* **Documentation**
  * CLI and docs updated to list the new "OVERRIDE" arming-disabled flag and explain its behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->