### PR TITLE
Set default for pin swap to be on 

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -241,7 +241,7 @@ the actual values are calculated automatically (#332).
 
 `fbus_master_frame_rate` defaults to 500 Hz.
 
-`fbus_master_pinswap` defaults to OFF (0).
+`fbus_master_pinswap` defaults to ON (1).
 
 `fbus_master_inverted` defaults to ON (SERIAL_INVERTED), which is the standard for FBUS receivers.
 

--- a/src/main/pg/fbus_master.c
+++ b/src/main/pg/fbus_master.c
@@ -28,7 +28,8 @@ PG_REGISTER_WITH_RESET_FN(fbusMasterConfig_t, fbusMasterConfig,
 
 void pgResetFn_fbusMasterConfig(fbusMasterConfig_t *config) {
     config->frameRate = 500;
-    config->pinSwap = 0;
+    // Default to swapped TX/RX pins for the FBUS master serial port.
+    config->pinSwap = 1;
     // Default to inverted F.Bus (normal for F.Bus receivers).
     config->inverted = 1;
 }


### PR DESCRIPTION
Anybody using FBUS master will likely be on nexus or 007

The feature always requires pinswap to be on - so setting as the default value makes sense.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration Changes**
  * FBUS Master serial port TX/RX pin swapping is now enabled by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->