### PR TITLE
CMS, rates menu update and more.

### DIFF
--- a/src/main/cms/cms.c
+++ b/src/main/cms/cms.c
@@ -1011,8 +1011,8 @@ const void *cmsMenuExit(displayPort_t *pDisplay, const void *ptr)
 
 // Stick/key detection and key codes
 
-#define IS_HI(X)  (rcCommand[X] > 400)
-#define IS_LO(X)  (rcCommand[X] < -400)
+#define IS_HI(X)  (rcCommand[X] > 300)
+#define IS_LO(X)  (rcCommand[X] < -300)
 #define IS_MID(X) (rcCommand[X] > -100 && rcCommand[X] < 100)
 
 #define BUTTON_TIME   250 // msec

--- a/src/main/cms/cms.h
+++ b/src/main/cms/cms.h
@@ -56,9 +56,9 @@ void cmsSetExternKey(cms_key_e extKey);
 void inhibitSaveMenu(void);
 void cmsAddMenuEntry(OSD_Entry *menuEntry, char *text, uint16_t flags, CMSEntryFuncPtr func, void *data);
 
-#define CMS_STARTUP_HELP_TEXT1 "MENU:THR MID"
+#define CMS_STARTUP_HELP_TEXT1     "CMS: THR MID"
 #define CMS_STARTUP_HELP_TEXT2     "+ YAW LEFT"
-#define CMS_STARTUP_HELP_TEXT3     "+ PITCH UP"
+#define CMS_STARTUP_HELP_TEXT3     "+ PITCH FWD"
 
 // cmsMenuExit special ptr values
 #define CMS_EXIT             (0)

--- a/src/main/cms/cms_menu_imu.c
+++ b/src/main/cms/cms_menu_imu.c
@@ -284,20 +284,23 @@ static const OSD_Entry cmsx_menuRateProfileEntries[] =
 {
     { "-- RATE --", OME_Label, NULL, rateProfileIndexString },
 
-    { "RC R RATE",   OME_UINT8,  NULL, &(OSD_UINT8_t) { &rateProfile.rcRates[FD_ROLL],  1, CONTROL_RATE_CONFIG_RC_RATES_MAX, 1 }},
-    { "RC P RATE",   OME_UINT8,  NULL, &(OSD_UINT8_t) { &rateProfile.rcRates[FD_PITCH], 1, CONTROL_RATE_CONFIG_RC_RATES_MAX, 1}},
-    { "RC Y RATE",   OME_UINT8,  NULL, &(OSD_UINT8_t) { &rateProfile.rcRates[FD_YAW],   1, CONTROL_RATE_CONFIG_RC_RATES_MAX, 1 }},
+    { "R RATE",   OME_UINT8,  NULL, &(OSD_UINT8_t) { &rateProfile.rcRates[FD_ROLL],  1, CONTROL_RATE_CONFIG_RC_RATES_MAX, 1 }},
+    { "P RATE",   OME_UINT8,  NULL, &(OSD_UINT8_t) { &rateProfile.rcRates[FD_PITCH], 1, CONTROL_RATE_CONFIG_RC_RATES_MAX, 1 }},
+    { "Y RATE",   OME_UINT8,  NULL, &(OSD_UINT8_t) { &rateProfile.rcRates[FD_YAW],   1, CONTROL_RATE_CONFIG_RC_RATES_MAX, 1 }},
+    { "C RATE",   OME_UINT8,  NULL, &(OSD_UINT8_t) { &rateProfile.rcRates[FD_COLL],  1, CONTROL_RATE_CONFIG_RC_RATES_MAX, 1 }},
 
-    { "ROLL SUPER",  OME_UINT8,  NULL, &(OSD_UINT8_t) { &rateProfile.sRates[FD_ROLL],    0, CONTROL_RATE_CONFIG_SUPER_RATE_MAX, 1 }},
-    { "PITCH SUPER", OME_UINT8,  NULL, &(OSD_UINT8_t) { &rateProfile.sRates[FD_PITCH],   0, CONTROL_RATE_CONFIG_SUPER_RATE_MAX, 1 }},
-    { "YAW SUPER",   OME_UINT8,  NULL, &(OSD_UINT8_t) { &rateProfile.sRates[FD_YAW],     0, CONTROL_RATE_CONFIG_SUPER_RATE_MAX, 1 }},
+    { "R SHAPE",  OME_UINT8,  NULL, &(OSD_UINT8_t) { &rateProfile.sRates[FD_ROLL],    0, CONTROL_RATE_CONFIG_SUPER_RATE_MAX, 1 }},
+    { "P SHAPE",  OME_UINT8,  NULL, &(OSD_UINT8_t) { &rateProfile.sRates[FD_PITCH],   0, CONTROL_RATE_CONFIG_SUPER_RATE_MAX, 1 }},
+    { "Y SHAPE",  OME_UINT8,  NULL, &(OSD_UINT8_t) { &rateProfile.sRates[FD_YAW],     0, CONTROL_RATE_CONFIG_SUPER_RATE_MAX, 1 }},
+    { "C SHAPE",  OME_UINT8,  NULL, &(OSD_UINT8_t) { &rateProfile.sRates[FD_COLL],    0, CONTROL_RATE_CONFIG_SUPER_RATE_MAX, 1 }},
 
-    { "RC R EXPO",   OME_UINT8,  NULL, &(OSD_UINT8_t) { &rateProfile.rcExpo[FD_ROLL],   0, 100, 1 }},
-    { "RC P EXPO",   OME_UINT8,  NULL, &(OSD_UINT8_t) { &rateProfile.rcExpo[FD_PITCH],  0, 100, 1 }},
-    { "RC Y EXPO",   OME_UINT8,  NULL, &(OSD_UINT8_t) { &rateProfile.rcExpo[FD_YAW],    0, 100, 1 }},
+    { "R EXPO",   OME_UINT8,  NULL, &(OSD_UINT8_t) { &rateProfile.rcExpo[FD_ROLL],   0, 100, 1 }},
+    { "P EXPO",   OME_UINT8,  NULL, &(OSD_UINT8_t) { &rateProfile.rcExpo[FD_PITCH],  0, 100, 1 }},
+    { "Y EXPO",   OME_UINT8,  NULL, &(OSD_UINT8_t) { &rateProfile.rcExpo[FD_YAW],    0, 100, 1 }},
+    { "C EXPO",   OME_UINT8,  NULL, &(OSD_UINT8_t) { &rateProfile.rcExpo[FD_COLL],   0, 100, 1 }},
 
-    { "ROLL LVL EXPO",  OME_UINT8, NULL, &(OSD_UINT8_t) { &rateProfile.levelExpo[FD_ROLL],  0, 100, 1 }},
-    { "PITCH LVL EXPO", OME_UINT8, NULL, &(OSD_UINT8_t) { &rateProfile.levelExpo[FD_PITCH], 0, 100, 1 }},
+    { "R LEVEL EXPO", OME_UINT8, NULL, &(OSD_UINT8_t) { &rateProfile.levelExpo[FD_ROLL],  0, 100, 1 }},
+    { "P LEVEL EXPO", OME_UINT8, NULL, &(OSD_UINT8_t) { &rateProfile.levelExpo[FD_PITCH], 0, 100, 1 }},
 
     { "BACK", OME_Back, NULL, NULL },
     { NULL, OME_END, NULL, NULL}

--- a/src/main/osd/osd.c
+++ b/src/main/osd/osd.c
@@ -116,8 +116,8 @@ const char * const osdTimerSourceNames[] = {
 
 // Things in both OSD and CMS
 
-#define IS_HI(X)  (rcCommand[X] > 400)
-#define IS_LO(X)  (rcCommand[X] < -400)
+#define IS_HI(X)  (rcCommand[X] > 300)
+#define IS_LO(X)  (rcCommand[X] < -300)
 #define IS_MID(X) (rcCommand[X] > -100 && rcCommand[X] < 100)
 
 timeUs_t osdFlyTime = 0;


### PR DESCRIPTION
A few small fixes in CMS:

- Rates menus cleaned up and change to somewhat match Configurator names,  "Shape" in particular.
- Added collective rates.
- Entry menu rephrased. "CMS" was not mentioned before and "Pitch Up" could be misunderstood.
- Relaxed stick thresholds. With Spektrum and RF default channel endpoints, stick detection was unreliable. 

Please also merge to 4.6, if not already too late.
/A 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tuned stick/key detection thresholds to improve input responsiveness and control sensitivity

* **UI & Documentation Improvements**
  * Updated CMS startup help text for clearer guidance
  * Reorganized rate profile menu with a new control-axis entry and clearer, abbreviated labels for easier navigation
<!-- end of auto-generated comment: release notes by coderabbit.ai -->