### PR TITLE
Add msp command to retrieve the current setpoint for each axis

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -146,6 +146,10 @@ New MSP command to get the active battery profile. (#415)
 
 New MSP command to set the active battery profile. (#415)
 
+### MSP_SETPOINT
+
+New MSP command to get the current setpoint. (#443)
+
 
 ## CLI Changes
 

--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -1374,7 +1374,7 @@ static bool mspProcessOutCommand(int16_t cmdMSP, sbuf_t *dst)
 
     case MSP_SETPOINT:
         for (int i = 0; i < 4; i++) {
-            sbufWriteU16(dst, lrintf(getSetpoint(i)));
+            sbufWriteS16(dst, lrintf(getSetpoint(i)));
         }
         break;
 

--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -1374,7 +1374,7 @@ static bool mspProcessOutCommand(int16_t cmdMSP, sbuf_t *dst)
 
     case MSP_SETPOINT:
         for (int i = 0; i < 4; i++) {
-            sbufWriteS16(dst, lrintf(getSetpoint(i)));
+            sbufWriteS16(dst, lrintf(getSetpoint(i) * 10));
         }
         break;
 

--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -1372,6 +1372,12 @@ static bool mspProcessOutCommand(int16_t cmdMSP, sbuf_t *dst)
         }
         break;
 
+    case MSP_SETPOINT:
+        for (int i = 0; i < 4; i++) {
+            sbufWriteU16(dst, lrintf(getSetpoint(i)));
+        }
+        break;
+
     case MSP_ATTITUDE:
         sbufWriteU16(dst, attitude.values.roll);
         sbufWriteU16(dst, attitude.values.pitch);

--- a/src/main/msp/msp_protocol.h
+++ b/src/main/msp/msp_protocol.h
@@ -162,6 +162,7 @@
 #define MSP_PID_TUNING                       112
 #define MSP_RC_COMMAND                       113
 #define MSP_RX_CHANNELS                      114
+#define MSP_SETPOINT                         115
 
 #define MSP_BOXNAMES                         116
 


### PR DESCRIPTION
To be used for accurately displaying rates preview in the configurator.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an MSP command to retrieve the current setpoint values (returns four axis setpoints).

* **Documentation**
  * Changelog/documentation updated with the new MSP command entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->