### PR TITLE
Fix buffer overflow in RX protocols

### DIFF
--- a/src/main/rx/crsf.c
+++ b/src/main/rx/crsf.c
@@ -555,6 +555,11 @@ STATIC_UNIT_TESTED uint8_t crsfFrameStatus(rxRuntimeState_t *rxRuntimeState)
 
             // calculate the number of channels packed
             uint8_t numOfChannels = ((crsfChannelDataFrame.frame.frameLength - CRSF_FRAME_LENGTH_TYPE_CRC - 1) * 8) / channelBits;
+            if (startChannel >= CRSF_MAX_CHANNEL) {
+                return RX_FRAME_DROPPED;
+            }
+
+            numOfChannels = MIN(numOfChannels, CRSF_MAX_CHANNEL - startChannel);
 
             // unpack the channel data
             uint8_t bitsMerged = 0;

--- a/src/main/rx/crsf.c
+++ b/src/main/rx/crsf.c
@@ -393,6 +393,10 @@ STATIC_UNIT_TESTED void crsfDataReceive(uint16_t c, void *data)
 #endif
                 switch (crsfFrame.frame.type) {
                 case CRSF_FRAMETYPE_RC_CHANNELS_PACKED:
+                    if (crsfFrame.frame.frameLength != (CRSF_FRAME_RC_CHANNELS_PAYLOAD_SIZE + CRSF_FRAME_LENGTH_TYPE_CRC)) {
+                        break;
+                    }
+                    FALLTHROUGH;
                 case CRSF_FRAMETYPE_SUBSET_RC_CHANNELS_PACKED:
                     if (crsfFrame.frame.deviceAddress == CRSF_ADDRESS_FLIGHT_CONTROLLER) {
                         rxRuntimeState->lastRcFrameTimeUs = currentTimeUs;
@@ -490,6 +494,10 @@ STATIC_UNIT_TESTED uint8_t crsfFrameStatus(rxRuntimeState_t *rxRuntimeState)
 
         // unpack the RC channels
         if (crsfChannelDataFrame.frame.type == CRSF_FRAMETYPE_RC_CHANNELS_PACKED) {
+            if (crsfChannelDataFrame.frame.frameLength != (CRSF_FRAME_RC_CHANNELS_PAYLOAD_SIZE + CRSF_FRAME_LENGTH_TYPE_CRC)) {
+                return RX_FRAME_DROPPED;
+            }
+
             // use ordinary RC frame structure (0x16)
             const crsfPayloadRcChannelsPacked_t* const rcChannels = (crsfPayloadRcChannelsPacked_t*)&crsfChannelDataFrame.frame.payload;
             channelScale = CRSF_RC_CHANNEL_SCALE_LEGACY;

--- a/src/main/rx/ghst.c
+++ b/src/main/rx/ghst.c
@@ -109,6 +109,7 @@ static uint8_t telemetryBufLen = 0;
 #define GHST_FRAME_LENGTH_ADDRESS       1
 #define GHST_FRAME_LENGTH_FRAMELENGTH   1
 #define GHST_FRAME_LENGTH_TYPE_CRC      1
+#define GHST_FRAME_LENGTH_MIN           2                   // at least type + CRC
 #define GHST_FRAME_LENGTH_MAX           (GHST_FRAME_SIZE - GHST_FRAME_LENGTH_ADDRESS - GHST_FRAME_LENGTH_FRAMELENGTH)
 
 // called from telemetry/ghst.c
@@ -157,7 +158,7 @@ STATIC_UNIT_TESTED void ghstDataReceive(uint16_t c, void *data)
     }
 
     if (ghstFrameIdx == GHST_FRAME_LENGTH_ADDRESS) {
-        if (((uint8_t)c < GHST_FRAME_LENGTH_TYPE_CRC) || ((uint8_t)c > GHST_FRAME_LENGTH_MAX)) {
+        if (((uint8_t)c < GHST_FRAME_LENGTH_MIN) || ((uint8_t)c > GHST_FRAME_LENGTH_MAX)) {
             ghstFrameIdx = 0;
             return;
         }
@@ -225,7 +226,7 @@ STATIC_UNIT_TESTED uint8_t ghstFrameStatus(rxRuntimeState_t *rxRuntimeState)
         ghstFrameAvailable = false;
 
         const int fullFrameLength = ghstValidatedFrame.frame.len + GHST_FRAME_LENGTH_ADDRESS + GHST_FRAME_LENGTH_FRAMELENGTH;
-        if ((ghstValidatedFrame.frame.len < GHST_FRAME_LENGTH_TYPE_CRC) || (fullFrameLength > (int)sizeof(ghstValidatedFrame.bytes))) {
+        if ((ghstValidatedFrame.frame.len < GHST_FRAME_LENGTH_MIN) || (fullFrameLength > (int)sizeof(ghstValidatedFrame.bytes))) {
             return RX_FRAME_DROPPED;
         }
 

--- a/src/main/rx/ghst.c
+++ b/src/main/rx/ghst.c
@@ -109,6 +109,7 @@ static uint8_t telemetryBufLen = 0;
 #define GHST_FRAME_LENGTH_ADDRESS       1
 #define GHST_FRAME_LENGTH_FRAMELENGTH   1
 #define GHST_FRAME_LENGTH_TYPE_CRC      1
+#define GHST_FRAME_LENGTH_MAX           (GHST_FRAME_SIZE - GHST_FRAME_LENGTH_ADDRESS - GHST_FRAME_LENGTH_FRAMELENGTH)
 
 // called from telemetry/ghst.c
 void ghstRxWriteTelemetryData(const void *data, int len)
@@ -155,11 +156,18 @@ STATIC_UNIT_TESTED void ghstDataReceive(uint16_t c, void *data)
         ghstRxFrameStartAtUs = currentTimeUs;
     }
 
+    if (ghstFrameIdx == GHST_FRAME_LENGTH_ADDRESS) {
+        if (((uint8_t)c < GHST_FRAME_LENGTH_TYPE_CRC) || ((uint8_t)c > GHST_FRAME_LENGTH_MAX)) {
+            ghstFrameIdx = 0;
+            return;
+        }
+    }
+
     // assume frame is 5 bytes long until we have received the frame length
     // full frame length includes the length of the address and framelength fields
     const int fullFrameLength = ghstFrameIdx < 3 ? 5 : ghstIncomingFrame.frame.len + GHST_FRAME_LENGTH_ADDRESS + GHST_FRAME_LENGTH_FRAMELENGTH;
 
-    if (ghstFrameIdx < fullFrameLength) {
+    if (ghstFrameIdx < fullFrameLength && ghstFrameIdx < (int)sizeof(ghstIncomingFrame.bytes)) {
         ghstIncomingFrame.bytes[ghstFrameIdx++] = (uint8_t)c;
         if (ghstFrameIdx >= fullFrameLength) {
             ghstFrameIdx = 0;
@@ -172,6 +180,8 @@ STATIC_UNIT_TESTED void ghstDataReceive(uint16_t c, void *data)
             // remember what time the incoming (Rx) packet ended, so that we can ensure a quite bus before sending telemetry
             ghstRxFrameEndAtUs = microsISR();
         }
+    } else {
+        ghstFrameIdx = 0;
     }
 }
 
@@ -190,8 +200,12 @@ STATIC_UNIT_TESTED uint8_t ghstFrameStatus(rxRuntimeState_t *rxRuntimeState)
     if (ghstFrameAvailable) {
         ghstFrameAvailable = false;
 
-        const uint8_t crc = ghstFrameCRC(&ghstValidatedFrame);
         const int fullFrameLength = ghstValidatedFrame.frame.len + GHST_FRAME_LENGTH_ADDRESS + GHST_FRAME_LENGTH_FRAMELENGTH;
+        if ((ghstValidatedFrame.frame.len < GHST_FRAME_LENGTH_TYPE_CRC) || (fullFrameLength > (int)sizeof(ghstValidatedFrame.bytes))) {
+            return RX_FRAME_DROPPED;
+        }
+
+        const uint8_t crc = ghstFrameCRC(&ghstValidatedFrame);
         if (crc == ghstValidatedFrame.bytes[fullFrameLength - 1] && ghstValidatedFrame.frame.addr == GHST_ADDR_FC) {
             ghstValidatedFrameAvailable = true;
             rxRuntimeState->lastRcFrameTimeUs = ghstRxFrameEndAtUs;

--- a/src/main/rx/ghst.c
+++ b/src/main/rx/ghst.c
@@ -192,6 +192,30 @@ static bool shouldSendTelemetryFrame(void)
     return telemetryBufLen > 0 && timeSinceRxFrameEndUs > GHST_RX_TO_TELEMETRY_MIN_US && timeSinceRxFrameEndUs < GHST_RX_TO_TELEMETRY_MAX_US;
 }
 
+static bool ghstFramePayloadLengthIsValid(const ghstFrame_t *frame)
+{
+    const int payloadLength = frame->frame.len - GHST_FRAME_LENGTH_TYPE_CRC - 1;
+
+    if (frame->frame.type < GHST_UL_RC_CHANS_HS4_FIRST || frame->frame.type > GHST_UL_RC_CHANS_HS4_LAST) {
+        return true;
+    }
+
+    if (payloadLength < (int)sizeof(ghstPayloadServo4_t)) {
+        return false;
+    }
+
+    switch (frame->frame.type) {
+    case GHST_UL_RC_CHANS_HS4_RSSI:
+        return payloadLength >= (int)sizeof(ghstPayloadPulsesRssi_t);
+    case GHST_UL_RC_CHANS_HS4_5TO8:
+    case GHST_UL_RC_CHANS_HS4_9TO12:
+    case GHST_UL_RC_CHANS_HS4_13TO16:
+        return payloadLength >= (int)sizeof(ghstPayloadPulses_t);
+    default:
+        return true;
+    }
+}
+
 STATIC_UNIT_TESTED uint8_t ghstFrameStatus(rxRuntimeState_t *rxRuntimeState)
 {
     UNUSED(rxRuntimeState);
@@ -207,6 +231,10 @@ STATIC_UNIT_TESTED uint8_t ghstFrameStatus(rxRuntimeState_t *rxRuntimeState)
 
         const uint8_t crc = ghstFrameCRC(&ghstValidatedFrame);
         if (crc == ghstValidatedFrame.bytes[fullFrameLength - 1] && ghstValidatedFrame.frame.addr == GHST_ADDR_FC) {
+            if (!ghstFramePayloadLengthIsValid(&ghstValidatedFrame)) {
+                return RX_FRAME_DROPPED;
+            }
+
             ghstValidatedFrameAvailable = true;
             rxRuntimeState->lastRcFrameTimeUs = ghstRxFrameEndAtUs;
             return RX_FRAME_COMPLETE | RX_FRAME_PROCESSING_REQUIRED;            // request callback through ghstProcessFrame to do the decoding  work
@@ -242,6 +270,8 @@ static bool ghstProcessFrame(const rxRuntimeState_t *rxRuntimeState)
     }
 
     if (ghstValidatedFrameAvailable) {
+        ghstValidatedFrameAvailable = false;
+
         int startIdx = 0;
 
         if (ghstValidatedFrame.frame.type >= GHST_UL_RC_CHANS_HS4_FIRST &&

--- a/src/main/rx/ibus.c
+++ b/src/main/rx/ibus.c
@@ -71,7 +71,7 @@ static uint8_t ibusChannelOffset;
 static uint8_t rxBytesToIgnore;
 static uint16_t ibusChecksum;
 
-static bool ibusFrameDone = false;
+static volatile bool ibusFrameDone = false;
 static uint32_t ibusChannelData[IBUS_MAX_CHANNEL];
 
 static uint8_t ibus[IBUS_BUFFSIZE] = { 0, };
@@ -119,6 +119,11 @@ static void ibusDataReceive(uint16_t c, void *data)
         } else if (ibusSyncByte != c) {
             return;
         }
+    }
+
+    if ((ibusFrameSize == 0) || (ibusFrameSize > IBUS_BUFFSIZE) || (ibusFramePosition >= ibusFrameSize)) {
+        ibusFramePosition = 0;
+        return;
     }
 
     ibus[ibusFramePosition] = (uint8_t)c;

--- a/src/main/rx/jetiexbus.c
+++ b/src/main/rx/jetiexbus.c
@@ -67,11 +67,6 @@
 
 // jetiExBusDecodeChannelFrame() reads 16 packed 16-bit channel values after the header; shorter
 // CRC-valid frames must be rejected or stale buffer bytes past MSG_LEN would be interpreted as RC.
-#define JETIEXBUS_MIN_CHANNEL_FRAME_LEN (EXBUS_HEADER_LEN + JETIEXBUS_CHANNEL_COUNT * 2 + EXBUS_CRC_LEN)
-
-#if JETIEXBUS_MIN_CHANNEL_FRAME_LEN > EXBUS_MAX_CHANNEL_FRAME_SIZE
-#error JETIEXBUS_MIN_CHANNEL_FRAME_LEN exceeds EXBUS_MAX_CHANNEL_FRAME_SIZE
-#endif
 
 #define EXBUS_START_CHANNEL_FRAME       (0x3E)
 #define EXBUS_START_REQUEST_FRAME       (0x3D)
@@ -204,8 +199,7 @@ static void jetiExBusDataReceive(uint16_t c, void *data)
     if (jetiExBusFramePosition == EXBUS_HEADER_LEN) {
 
         if ((jetiExBusFrameState == EXBUS_STATE_IN_PROGRESS) &&
-            (jetiExBusFrame[EXBUS_HEADER_MSG_LEN] >= JETIEXBUS_MIN_CHANNEL_FRAME_LEN) &&
-            (jetiExBusFrame[EXBUS_HEADER_MSG_LEN] <= EXBUS_MAX_CHANNEL_FRAME_SIZE)) {
+            (jetiExBusFrame[EXBUS_HEADER_MSG_LEN] == EXBUS_MAX_CHANNEL_FRAME_SIZE)) {
             jetiExBusFrameLength = jetiExBusFrame[EXBUS_HEADER_MSG_LEN];
             return;
         }
@@ -245,7 +239,7 @@ static uint8_t jetiExBusFrameStatus(rxRuntimeState_t *rxRuntimeState)
 
     if (jetiExBusFrameState == EXBUS_STATE_RECEIVED) {
         const uint8_t msg_len = jetiExBusChannelFrame[EXBUS_HEADER_MSG_LEN];
-        if ((msg_len >= JETIEXBUS_MIN_CHANNEL_FRAME_LEN) &&
+        if ((msg_len == EXBUS_MAX_CHANNEL_FRAME_SIZE) &&
             (jetiExBusCalcCRC16(jetiExBusChannelFrame, msg_len) == 0)) {
             jetiExBusDecodeChannelFrame(jetiExBusChannelFrame);
             frameStatus = RX_FRAME_COMPLETE;

--- a/src/main/rx/jetiexbus.c
+++ b/src/main/rx/jetiexbus.c
@@ -83,8 +83,8 @@ uint32_t jetiTimeStampRequest = 0;
 static uint8_t jetiExBusFramePosition;
 static uint8_t jetiExBusFrameLength;
 
-static uint8_t jetiExBusFrameState = EXBUS_STATE_ZERO;
-uint8_t jetiExBusRequestState = EXBUS_STATE_ZERO;
+static volatile uint8_t jetiExBusFrameState = EXBUS_STATE_ZERO;
+volatile uint8_t jetiExBusRequestState = EXBUS_STATE_ZERO;
 
 // Use max values for ram areas
 static uint8_t jetiExBusChannelFrame[EXBUS_MAX_CHANNEL_FRAME_SIZE];
@@ -181,6 +181,14 @@ static void jetiExBusDataReceive(uint16_t c, void *data)
         }
     }
 
+    // Bounds check before writing to prevent buffer overflow
+    if (jetiExBusFramePosition >= jetiExBusFrameLength) {
+        jetiExBusFrameReset();
+        jetiExBusFrameState = EXBUS_STATE_ZERO;
+        jetiExBusRequestState = EXBUS_STATE_ZERO;
+        return;
+    }
+
     // Store in frame copy
     jetiExBusFrame[jetiExBusFramePosition] = (uint8_t)c;
     jetiExBusFramePosition++;
@@ -188,12 +196,16 @@ static void jetiExBusDataReceive(uint16_t c, void *data)
     // Check the header for the message length
     if (jetiExBusFramePosition == EXBUS_HEADER_LEN) {
 
-        if ((jetiExBusFrameState == EXBUS_STATE_IN_PROGRESS) && (jetiExBusFrame[EXBUS_HEADER_MSG_LEN] <= EXBUS_MAX_CHANNEL_FRAME_SIZE)) {
+        if ((jetiExBusFrameState == EXBUS_STATE_IN_PROGRESS) &&
+            (jetiExBusFrame[EXBUS_HEADER_MSG_LEN] >= EXBUS_OVERHEAD) &&
+            (jetiExBusFrame[EXBUS_HEADER_MSG_LEN] <= EXBUS_MAX_CHANNEL_FRAME_SIZE)) {
             jetiExBusFrameLength = jetiExBusFrame[EXBUS_HEADER_MSG_LEN];
             return;
         }
 
-        if ((jetiExBusRequestState == EXBUS_STATE_IN_PROGRESS) && (jetiExBusFrame[EXBUS_HEADER_MSG_LEN] <= EXBUS_MAX_REQUEST_FRAME_SIZE)) {
+        if ((jetiExBusRequestState == EXBUS_STATE_IN_PROGRESS) &&
+            (jetiExBusFrame[EXBUS_HEADER_MSG_LEN] >= EXBUS_OVERHEAD) &&
+            (jetiExBusFrame[EXBUS_HEADER_MSG_LEN] <= EXBUS_MAX_REQUEST_FRAME_SIZE)) {
             jetiExBusFrameLength = jetiExBusFrame[EXBUS_HEADER_MSG_LEN];
             return;
         }

--- a/src/main/rx/jetiexbus.c
+++ b/src/main/rx/jetiexbus.c
@@ -65,6 +65,13 @@
 #define JETIEXBUS_MIN_FRAME_GAP     1000
 #define JETIEXBUS_CHANNEL_COUNT     16                  // most Jeti TX transmit 16 channels
 
+// jetiExBusDecodeChannelFrame() reads 16 packed 16-bit channel values after the header; shorter
+// CRC-valid frames must be rejected or stale buffer bytes past MSG_LEN would be interpreted as RC.
+#define JETIEXBUS_MIN_CHANNEL_FRAME_LEN (EXBUS_HEADER_LEN + JETIEXBUS_CHANNEL_COUNT * 2 + EXBUS_CRC_LEN)
+
+#if JETIEXBUS_MIN_CHANNEL_FRAME_LEN > EXBUS_MAX_CHANNEL_FRAME_SIZE
+#error JETIEXBUS_MIN_CHANNEL_FRAME_LEN exceeds EXBUS_MAX_CHANNEL_FRAME_SIZE
+#endif
 
 #define EXBUS_START_CHANNEL_FRAME       (0x3E)
 #define EXBUS_START_REQUEST_FRAME       (0x3D)
@@ -197,7 +204,7 @@ static void jetiExBusDataReceive(uint16_t c, void *data)
     if (jetiExBusFramePosition == EXBUS_HEADER_LEN) {
 
         if ((jetiExBusFrameState == EXBUS_STATE_IN_PROGRESS) &&
-            (jetiExBusFrame[EXBUS_HEADER_MSG_LEN] >= EXBUS_OVERHEAD) &&
+            (jetiExBusFrame[EXBUS_HEADER_MSG_LEN] >= JETIEXBUS_MIN_CHANNEL_FRAME_LEN) &&
             (jetiExBusFrame[EXBUS_HEADER_MSG_LEN] <= EXBUS_MAX_CHANNEL_FRAME_SIZE)) {
             jetiExBusFrameLength = jetiExBusFrame[EXBUS_HEADER_MSG_LEN];
             return;
@@ -237,7 +244,9 @@ static uint8_t jetiExBusFrameStatus(rxRuntimeState_t *rxRuntimeState)
     uint8_t frameStatus = RX_FRAME_PENDING;
 
     if (jetiExBusFrameState == EXBUS_STATE_RECEIVED) {
-        if (jetiExBusCalcCRC16(jetiExBusChannelFrame, jetiExBusChannelFrame[EXBUS_HEADER_MSG_LEN]) == 0) {
+        const uint8_t msg_len = jetiExBusChannelFrame[EXBUS_HEADER_MSG_LEN];
+        if ((msg_len >= JETIEXBUS_MIN_CHANNEL_FRAME_LEN) &&
+            (jetiExBusCalcCRC16(jetiExBusChannelFrame, msg_len) == 0)) {
             jetiExBusDecodeChannelFrame(jetiExBusChannelFrame);
             frameStatus = RX_FRAME_COMPLETE;
             rxRuntimeState->lastRcFrameTimeUs = jetiTimeStampRequest;

--- a/src/main/rx/jetiexbus.h
+++ b/src/main/rx/jetiexbus.h
@@ -45,7 +45,7 @@ enum {
     EXBUS_STATE_PROCESSED
 };
 
-extern uint8_t jetiExBusRequestState;
+extern volatile uint8_t jetiExBusRequestState;
 extern uint32_t jetiTimeStampRequest;
 extern uint8_t jetiExBusRequestFrame[EXBUS_MAX_REQUEST_FRAME_SIZE];
 struct serialPort_s;

--- a/src/main/rx/sbus.c
+++ b/src/main/rx/sbus.c
@@ -107,9 +107,9 @@ typedef union sbusFrame_u {
 
 typedef struct sbusFrameData_s {
     sbusFrame_t frame;
-    timeUs_t startAtUs;
-    uint8_t position;
-    bool done;
+    volatile timeUs_t startAtUs;
+    volatile uint8_t position;
+    volatile bool done;
 } sbusFrameData_t;
 
 #ifdef USE_TELEMETRY_SBUS2

--- a/src/main/rx/spektrum.c
+++ b/src/main/rx/spektrum.c
@@ -63,7 +63,7 @@ uint8_t rssi_channel;
 
 static uint8_t spek_chan_shift;
 static uint8_t spek_chan_mask;
-static bool rcFrameComplete = false;
+static volatile bool rcFrameComplete = false;
 static bool spekHiRes = false;
 
 static volatile uint8_t spekFrame[SPEK_FRAME_SIZE];

--- a/src/main/rx/sumd.c
+++ b/src/main/rx/sumd.c
@@ -69,13 +69,13 @@
 #define SUMDV3_FRAME_STATE_OK 0x03
 #define SUMD_FRAME_STATE_FAILSAFE 0x81
 
-static bool sumdFrameDone = false;
+static volatile bool sumdFrameDone = false;
 static uint16_t sumdChannels[MAX_SUPPORTED_RC_CHANNEL_COUNT];
-static uint16_t crc;
+static volatile uint16_t crc;
 
 static uint8_t sumd[SUMD_BUFFSIZE] = { 0, };
-static uint8_t sumdChannelCount;
-static timeUs_t lastFrameTimeUs = 0;
+static volatile uint8_t sumdChannelCount;
+static volatile timeUs_t lastFrameTimeUs = 0;
 
 // Receive ISR callback
 static void sumdDataReceive(uint16_t c, void *data)

--- a/src/main/rx/sumd.c
+++ b/src/main/rx/sumd.c
@@ -99,6 +99,11 @@ static void sumdDataReceive(uint16_t c, void *data)
             crc = 0;
         }
     } else if (sumdIndex == SUMD_CHANNEL_COUNT_INDEX) {
+        if ((c == 0) || (c > SUMD_MAX_CHANNEL)) {
+            sumdIndex = 0;
+            return;
+        }
+
         sumdChannelCount = (uint8_t)c;
     }
 
@@ -127,6 +132,10 @@ static uint8_t sumdFrameStatus(rxRuntimeState_t *rxRuntimeState)
     }
 
     sumdFrameDone = false;
+
+    if ((sumdChannelCount == 0) || (sumdChannelCount > SUMD_MAX_CHANNEL)) {
+        return RX_FRAME_DROPPED;
+    }
 
     // verify CRC
     if (crc == ((sumd[SUMD_BYTES_PER_CHANNEL * sumdChannelCount + SUMD_OFFSET_CHANNEL_1_HIGH] << 8) |

--- a/src/main/rx/sumh.c
+++ b/src/main/rx/sumh.c
@@ -52,7 +52,7 @@
 #define SUMH_MAX_CHANNEL_COUNT 8
 #define SUMH_FRAME_SIZE 21
 
-static bool sumhFrameDone = false;
+static volatile bool sumhFrameDone = false;
 
 static uint8_t sumhFrame[SUMH_FRAME_SIZE];
 static uint32_t sumhChannels[SUMH_MAX_CHANNEL_COUNT];
@@ -74,6 +74,11 @@ static void sumhDataReceive(uint16_t c, void *data)
     sumhTimeLast = sumhTime;
     if (sumhTimeInterval > 5000) {
         sumhFramePosition = 0;
+    }
+
+    if (sumhFramePosition >= SUMH_FRAME_SIZE) {
+        sumhFramePosition = 0;
+        return;
     }
 
     sumhFrame[sumhFramePosition] = (uint8_t) c;

--- a/src/main/rx/xbus.c
+++ b/src/main/rx/xbus.c
@@ -35,6 +35,7 @@
 #ifdef USE_SERIALRX_XBUS
 
 #include "common/crc.h"
+#include "common/maths.h"
 
 #include "drivers/time.h"
 
@@ -164,9 +165,15 @@ static uint8_t xBusRj01CRC8(uint8_t inData, uint8_t seed)
 
 static void xBusUnpackModeAFrame(uint8_t offsetBytes)
 {
+    // xBusFrame[1] (payload length) is validated by the ISR to be within
+    // [MIN_PAYLOAD_LENGTH, MAX_PAYLOAD_LENGTH], so n_num_channels is bounded
+    // by XBUS_MODEA_CHANNEL_COUNT and cannot overrun xBusFrame.
+    const uint8_t payload_length = xBusFrame[1];
+    const uint8_t n_num_channels = (payload_length - 2) / 4;
+
     // Calculate the CRC according to JR XBus Specs
     // Using a CRC lookup table is faster than without
-    if (crc8_dallas((uint8_t*)xBusFrame, xBusFrame[1] + 2) == xBusFrame[xBusFrame[1] + 2])
+    if (crc8_dallas((uint8_t*)xBusFrame, payload_length + 2) == xBusFrame[payload_length + 2])
     {
         // Need to do a check on bytes 2 and 3. 
         // When failsafe, byte 2 goes from >0 to 0 and byte 3 goes from 0 to a value that appears to be dependant on the TX
@@ -179,8 +186,7 @@ static void xBusUnpackModeAFrame(uint8_t offsetBytes)
             // data and update the corresponding channel. The reason for this is that the 
             // number of the channel may not always be in the same spot in the packet. Also
             // there are only 16 channels of data sent per packet
-            uint8_t nNumChannels = (xBusFrame[1] - 2) / 4; // Calculate the number of channels in the frame
-            for (int i = 0; i < nNumChannels; i++)
+            for (uint8_t i = 0; i < n_num_channels; i++)
             {
                 // Channel packets are constructed as such:
                 // Byte 0 - Channel number
@@ -208,6 +214,14 @@ static void xBusUnpackModeAFrame(uint8_t offsetBytes)
 
 static void xBusUnpackModeBFrame(uint8_t offsetBytes)
 {
+    if (xBusFrameLength < 3) {
+        return;
+    }
+
+    const uint8_t payload_bytes = xBusFrameLength - 3; // channel bytes between ID and CRC16
+    const uint8_t available_channels = payload_bytes / 2;
+    const uint8_t unpack_channels = MIN(xBusChannelCount, available_channels);
+
     // Calculate the CRC of the incoming frame
     // Calculate on all bytes except the final two CRC bytes
     const uint16_t inCrc = crc16_ccitt_update(0, (uint8_t*)&xBusFrame[offsetBytes], xBusFrameLength - 2);
@@ -217,7 +231,7 @@ static void xBusUnpackModeBFrame(uint8_t offsetBytes)
 
     if (crc == inCrc) {
         // Unpack the data, we have a valid frame, only 12 channel unpack also when receive 16 channel
-        for (int i = 0; i < xBusChannelCount; i++) {
+        for (uint8_t i = 0; i < unpack_channels; i++) {
 
             const uint8_t frameAddr = offsetBytes + 1 + i * 2;
             uint16_t value = ((uint16_t)xBusFrame[frameAddr]) << 8;

--- a/src/main/rx/xbus.c
+++ b/src/main/rx/xbus.c
@@ -97,6 +97,8 @@
 #define XBUS_MODEA_BAUDRATE 250000
 #define XBUS_MODEA_MAX_FRAME_TIME 2700 // 2760us round up to 2800 (69/[250k/10bits]=2760)
 #define XBUS_MODEA_START_OF_FRAME_BYTE (0xA4)
+#define XBUS_MODEA_MIN_PAYLOAD_LENGTH 2
+#define XBUS_MODEA_MAX_PAYLOAD_LENGTH (XBUS_MODEA_FRAME_SIZE - 3)
 // Mode A needs a different conversion as the resolution is 16bit, not 12bit
 //0x0000      800uSec
 //0x1249      900uSec(-60°, -75°, or -90°)
@@ -108,7 +110,7 @@
 static timeDelta_t xBusMaxFrameTime;
 static timeUs_t xBusTimeLast = 0;
 
-static bool xBusFrameReceived = false;
+static volatile bool xBusFrameReceived = false;
 static bool xBusDataIncoming = false;
 static uint8_t xBusFramePosition;
 static uint8_t xBusFrameLength;
@@ -192,7 +194,7 @@ static void xBusUnpackModeAFrame(uint8_t offsetBytes)
                 value |= ((uint16_t)xBusFrame[frameAddr + 1]);
 
                 // Convert to internal format
-                if (nChannelNumber <= XBUS_MODEA_CHANNEL_COUNT)
+                if (nChannelNumber < XBUS_MODEA_CHANNEL_COUNT)
                 {
                     uint16_t val = XBUS_MODEA_CONVERT_TO_USEC(value);
 
@@ -310,6 +312,12 @@ static void xBusDataReceive(uint16_t c, void *data)
 
     // Only do this if we are receiving to a frame
     if (xBusDataIncoming == true) {
+        if (xBusFramePosition >= xBusFrameLength) {
+            xBusDataIncoming = false;
+            xBusFramePosition = 0;
+            return;
+        }
+
         // Store in frame copy
         xBusFrame[xBusFramePosition] = (uint8_t)c;
 
@@ -317,6 +325,12 @@ static void xBusDataReceive(uint16_t c, void *data)
         // adjust the frame length accordingly.
         // Packet length is the second byte of the array
         if (xBusProvider == SERIALRX_XBUS_MODE_A && xBusFramePosition == 1) {
+            if (((uint8_t)c < XBUS_MODEA_MIN_PAYLOAD_LENGTH) || ((uint8_t)c > XBUS_MODEA_MAX_PAYLOAD_LENGTH)) {
+                xBusDataIncoming = false;
+                xBusFramePosition = 0;
+                return;
+            }
+
             xBusFrameLength = (uint8_t)c + 3;   //adjust framesize
         }
         xBusFramePosition++;

--- a/src/test/unit/rx_crsf_unittest.cc.txt
+++ b/src/test/unit/rx_crsf_unittest.cc.txt
@@ -131,7 +131,7 @@ TEST(CrossFireTest, TestCrsfFrameStatus)
     crsfFrame.frame.payload[CRSF_FRAME_RC_CHANNELS_PAYLOAD_SIZE] = crc;
     memcpy(&crsfChannelDataFrame, &crsfFrame, sizeof(crsfFrame));
     const uint8_t status = crsfFrameStatus();
-    EXPECT_EQ(RX_FRAME_COMPLETE, status);
+    EXPECT_EQ(RX_FRAME_DROPPED, status);
     EXPECT_FALSE(crsfFrameDone);
 
     EXPECT_EQ(CRSF_ADDRESS_CRSF_RECEIVER, crsfFrame.frame.deviceAddress);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened receiver validation to reject malformed frames, enforce payload/length bounds, prevent buffer overruns, and avoid off-by-one channel writes across multiple protocols.
  * Improved handling of unexpected or out-of-range channel/count values to avoid invalid unpacking.
  * Hardened cross-context state visibility to ensure reliable real-time receiver behavior.

* **Tests**
  * Updated unit test expectations to reflect stricter frame validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->