### PR TITLE
Add freq_input_minhz parameter

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -212,6 +212,8 @@ the actual values are calculated automatically (#332).
 
 `fbus_master_inverted` parameter added (ON/OFF). Controls electrical inversion of the FBUS Master UART output.
 
+`freq_input_minhz` parameter added. Value in 1..100 Hz, sets the minimum accepted frequency on the input sensor.
+
 `rates_type` accepts `ROTORFLIGHT` (#345).
 
 `cyclic_ring` meaning is changed. The value indicates % of the max rate.

--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -769,6 +769,7 @@ const clivalue_t valueTable[] = {
 #if defined(USE_FREQ_SENSOR)
     { "freq_input_pull",            VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP,  .config.lookup = { TABLE_INPUT_PULL_MODE }, PG_FREQ_SENSOR_CONFIG, offsetof(freqConfig_t, pullupdn) },
     { "freq_input_edge",            VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP,  .config.lookup = { TABLE_INPUT_EDGE_MODE }, PG_FREQ_SENSOR_CONFIG, offsetof(freqConfig_t, polarity) },
+    { "freq_input_minhz",           VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 1, 100 }, PG_FREQ_SENSOR_CONFIG, offsetof(freqConfig_t, minhz) },
 #endif
 
 // PG_BLACKBOX_CONFIG

--- a/src/main/drivers/freq.c
+++ b/src/main/drivers/freq.c
@@ -39,10 +39,6 @@
 #include "pg/freq.h"
 
 
-// Accepted frequence range
-#define FREQ_RANGE_MIN        25
-#define FREQ_RANGE_MAX        10000
-
 // Prescaler limits
 #define FREQ_PRESCALER_MIN    0x0001
 
@@ -84,6 +80,9 @@ typedef struct {
 
     float freq;
     float clock;
+
+    float minhz;
+    float maxhz;
 
     uint16_t percoef;
     uint16_t freqcoef;
@@ -203,9 +202,9 @@ static FAST_CODE void freqEdgeCallback16(timerCCHandlerRec_t *cbRec, captureComp
             if (period) {
                 float freq = input->clock / (input->prescaler * period);
                 if (period > FREQ_PERIOD_MIN(input->period) && period < FREQ_PERIOD_MAX(input->period)) {
-                    if (freq < FREQ_RANGE_MIN)
+                    if (freq < input->minhz)
                         freq = 0;
-                    if (freq < FREQ_RANGE_MAX)
+                    if (freq < input->maxhz)
                         UPDATE_FREQ_FILTER(input, freq);
                 }
 
@@ -256,9 +255,9 @@ static FAST_CODE void freqEdgeCallback32(timerCCHandlerRec_t *cbRec, captureComp
             if (period) {
                 float freq = input->clock / period;
                 if (period > FREQ_PERIOD_MIN(input->period) && period < FREQ_PERIOD_MAX(input->period)) {
-                    if (freq < FREQ_RANGE_MIN)
+                    if (freq < input->minhz)
                         freq = 0;
-                    if (freq < FREQ_RANGE_MAX)
+                    if (freq < input->maxhz)
                         UPDATE_FREQ_FILTER(input, freq);
                 }
 
@@ -335,6 +334,8 @@ void freqInit(const freqConfig_t *freqConfig)
             input->timeout = FREQ_TIMEOUT(timerClock(timer->tim));
             input->percoef = 1;
             input->freqcoef = 1;
+            input->minhz = freqConfig->minhz;
+            input->maxhz = FREQ_INPUT_MAXHZ_DEFAULT;
             input->freq = 0;
 
             input->pin = IOGetByTag(freqConfig->ioTag[port]);

--- a/src/main/pg/freq.c
+++ b/src/main/pg/freq.c
@@ -39,6 +39,7 @@ void pgResetFn_freqConfig(freqConfig_t *freqConfig)
 
     freqConfig->pullupdn = FREQ_INPUT_PULLUP;
     freqConfig->polarity = FREQ_INPUT_FALLING_EDGE;
+    freqConfig->minhz = FREQ_INPUT_MINHZ_DEFAULT;
 }
 
 #endif

--- a/src/main/pg/freq.h
+++ b/src/main/pg/freq.h
@@ -33,10 +33,14 @@ enum {
     FREQ_INPUT_RISING_EDGE,
 };
 
+#define FREQ_INPUT_MINHZ_DEFAULT 25
+#define FREQ_INPUT_MAXHZ_DEFAULT 10000
+
 typedef struct freqConfig_s {
     ioTag_t ioTag[FREQ_SENSOR_PORT_COUNT];
     uint8_t pullupdn;
     uint8_t polarity;
+    uint8_t minhz;
 } freqConfig_t;
 
 PG_DECLARE(freqConfig_t, freqConfig);


### PR DESCRIPTION
Currently the minimum frequency for the RPM input is 25Hz. This is fine with electric motors / ESCs, but not low enough with magnetic sensors on the main shaft/gear. 
This change allows changing the min frequency to suite. Probably 2Hz is suitable for magnet on main shaft sensing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Frequency sensors now support configurable per-input minimum and maximum thresholds; inputs below the minimum are treated as zero and updates are gated by the maximum.
  * Added a CLI parameter to set the minimum input frequency (valid range 1–100 Hz) and sensible defaults for min/max.

* **Documentation**
  * Updated docs to describe the new frequency configuration parameter and defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->