### PR TITLE
Extended servo scaling for T-40 servos

### DIFF
--- a/src/main/flight/servos.h
+++ b/src/main/flight/servos.h
@@ -31,7 +31,7 @@
 
 #define SERVO_LIMIT_MIN      -1000
 #define SERVO_LIMIT_MAX       1000
-#define SERVO_SCALE_MIN        100
+#define SERVO_SCALE_MIN         50
 #define SERVO_SCALE_MAX       1000
 #define SERVO_RATE_MIN          25
 #define SERVO_RATE_MAX        5000


### PR DESCRIPTION
Configurator PR: https://github.com/rotorflight/rotorflight-configurator/pull/397

Needed to reach high angles for TB-40 servos at 250 center

<img width="4032" height="3024" alt="image" src="https://github.com/user-attachments/assets/dbe27187-7129-4f29-b9b6-aea11554d261" />
<img width="3024" height="4032" alt="image" src="https://github.com/user-attachments/assets/6cec99da-6d8e-4a2f-b550-4014e0314400" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted the minimum servo scaling constant from 100 to 50, allowing for a wider lower range in servo scaling calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->