### PR TITLE
Revert PR403. Caused glitches with Spektrum SRXL.

### DIFF
--- a/src/main/telemetry/srxl.c
+++ b/src/main/telemetry/srxl.c
@@ -848,10 +848,6 @@ static void processSrxl(timeUs_t currentTimeUs)
     sbuf_t *dst = &srxlPayloadBuf;
     srxlScheduleFnPtr srxlFnPtr;
 
-    bool tryNextUserFrame = true;
-    uint8_t tryNextUserCount = 0;
-
-  do {
     if (srxlScheduleIndex < SRXL_SCHEDULE_MANDATORY_COUNT) {
         srxlFnPtr = srxlScheduleFuncs[srxlScheduleIndex];
     } else {
@@ -873,14 +869,9 @@ static void processSrxl(timeUs_t currentTimeUs)
         srxlInitializeFrame(dst);
         if (srxlFnPtr(dst, currentTimeUs)) {
             srxlFinalize(dst);
-            tryNextUserFrame = false;
-            srxlScheduleIndex = (srxlScheduleIndex + 1) % SRXL_SCHEDULE_COUNT_MAX;
-        } else {
-            tryNextUserFrame = true;
-            tryNextUserCount++;
         }
     }
-  } while (tryNextUserFrame && tryNextUserCount < SRXL_SCHEDULE_USER_COUNT);
+    srxlScheduleIndex = (srxlScheduleIndex + 1) % SRXL_SCHEDULE_COUNT_MAX;
 }
 
 void initSrxlTelemetry(void)


### PR DESCRIPTION
Random glitches on channels with Spektrum SRXL and SPM4649T was seen with 4.6 RC1 and RC2, earlier snapshots was OK.. 
SRXl2 RXs was not affected. 
<img width="767" height="561" alt="SRXL-glitch" src="https://github.com/user-attachments/assets/4e5ad362-2176-4315-b3da-05aa8a863c2f" />
Reverting PR #403 fixes the issue.
Please also merge to master, 
