### PR TITLE
Remove unnecessary powf() in bmp388.c

### DIFF
--- a/src/main/drivers/barometer/barometer_bmp388.c
+++ b/src/main/drivers/barometer/barometer_bmp388.c
@@ -293,8 +293,8 @@ bool bmp388Detect(const bmp388Config_t *config, baroDev_t *baro)
 
     // See datasheet 3.9.2 "Measurement rate in forced mode and normal mode"
     baro->up_delay = 234 +
-        (392 + (powf(2, BMP388_PRESSURE_OSR + 1) * 2000)) +
-        (313 + (powf(2, BMP388_TEMPERATURE_OSR + 1) * 2000));
+        (392 + (2 << BMP388_PRESSURE_OSR) * 2000) +
+        (313 + (2 << BMP388_TEMPERATURE_OSR) * 2000);
 
     baro->calculate = bmp388Calculate;
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized barometer delay calculations for improved efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->