### PR TITLE
Make S.Port master independent of telemetry feature

### DIFF
--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -323,8 +323,7 @@ static void validateAndFixConfig(void)
     // or from standalone S.Port master.
 #if defined(USE_FBUS_MASTER) || defined(USE_SPORT_MASTER)
     const serialPortConfig_t *fbusMasterSerialForEsc = findSerialPortConfig(FUNCTION_FBUS_MASTER);
-    const bool hasSportMasterForEsc = featureIsConfigured(FEATURE_TELEMETRY)
-        && findSerialPortConfig(FUNCTION_SPORT_MASTER) != NULL;
+    const bool hasSportMasterForEsc = findSerialPortConfig(FUNCTION_SPORT_MASTER) != NULL;
     if (escSensorConfig()->protocol == ESC_SENSOR_PROTO_FBUS
         && (fbusMasterSerialForEsc || hasSportMasterForEsc)) {
         if (!featureIsConfigured(FEATURE_ESC_SENSOR)) {

--- a/src/main/fc/tasks.c
+++ b/src/main/fc/tasks.c
@@ -46,6 +46,7 @@
 #include "drivers/vtx_common.h"
 #include "drivers/sbus_output.h"
 #include "drivers/fbus_master.h"
+#include "drivers/fbus_sensor.h"
 
 #include "config/config.h"
 #include "fc/core.h"
@@ -302,6 +303,9 @@ static void taskTelemetry(timeUs_t currentTimeUs)
 static void taskSportMaster(timeUs_t currentTimeUs)
 {
     handleSportMaster(currentTimeUs);
+#ifndef USE_FBUS_MASTER
+    fbusSensorUpdate(currentTimeUs);
+#endif
 }
 #endif
 
@@ -610,4 +614,3 @@ void tasksInit(void)
 #endif
 
 }
-

--- a/src/main/io/gps.c
+++ b/src/main/io/gps.c
@@ -311,8 +311,7 @@ bool gpsUsesFbusTransport(void)
     }
 
     return findSerialPortConfig(FUNCTION_FBUS_MASTER) != NULL
-        || (featureIsEnabled(FEATURE_TELEMETRY)
-            && findSerialPortConfig(FUNCTION_SPORT_MASTER) != NULL);
+        || findSerialPortConfig(FUNCTION_SPORT_MASTER) != NULL;
 #else
     return false;
 #endif


### PR DESCRIPTION
## Summary

- Treat S.Port master as an input transport instead of requiring `FEATURE_TELEMETRY`.
- Allow FBUS-backed ESC and GPS detection to use a configured S.Port master port without telemetry enabled.
- Keep the FBUS sensor cache updated from the S.Port master task when FBUS master is not compiled in.

## Testing

- Tested and confirm no change in behaviour for sport or fbus sensors
- Sport Master will now work - even if telemetry feature is not enabled

## Notes

This keeps outbound telemetry behavior unchanged. The change only removes the telemetry feature dependency for S.Port master as a sensor ingress path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced FBUS/S.Port ESC sensor support to work independently of telemetry configuration status.
  * Improved FBus sensor data processing during flight controller execution.
  * Refined GPS FBUS transport detection for better compatibility with FBUS/S.Port setups.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rotorflight/rotorflight-firmware/pull/458)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->