### PR TITLE
fix: the rc device request parser writes incoming by... in rcdevice.c

### DIFF
--- a/src/main/io/rcdevice.c
+++ b/src/main/io/rcdevice.c
@@ -487,7 +487,8 @@ void rcdeviceReceive(timeUs_t currentTimeUs)
                 requestParserContext.state = RCDEVICE_STATE_WAITING_DATA;
                 break;
             case RCDEVICE_STATE_WAITING_DATA:
-                if (requestParserContext.request.dataLength < requestParserContext.expectedDataLength) {
+                if (requestParserContext.request.dataLength < requestParserContext.expectedDataLength &&
+                    requestParserContext.request.dataLength < sizeof(requestParserContext.request.data)) {
                     requestParserContext.request.data[requestParserContext.request.dataLength] = c;
                     requestParserContext.request.dataLength++;
                 }


### PR DESCRIPTION
## Summary
Fix critical severity security issue in `src/main/io/rcdevice.c`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | CRITICAL |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `src/main/io/rcdevice.c:490` |

**Description**: The RC device request parser writes incoming bytes into requestParserContext.request.data using dataLength as the array index, guarded only by a comparison against expectedDataLength. The expectedDataLength value is parsed directly from the incoming packet's length field without any validation against the actual allocated size of the data array. If an attacker sends a packet with a length field larger than sizeof(requestParserContext.request.data), the check at line 490 passes but successive writes overflow the buffer, overwriting adjacent stack or heap memory with attacker-controlled bytes.

## Changes
- `src/main/io/rcdevice.c`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed a potential buffer overflow vulnerability in RC device request handling by adding stricter validation to prevent payload data from exceeding the buffer capacity during processing.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rotorflight/rotorflight-firmware/pull/459)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->