### PR TITLE
Enable flight stats by default

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -277,6 +277,8 @@ the actual values are calculated automatically (#332).
 
 `offset_limit` default is changed to 90,90 (#425).
 
+`stats_min_armed_time_s` default is changed to 15 (#460).
+
 
 ## CRSF Custom Telemetry
 

--- a/src/main/pg/stats.c
+++ b/src/main/pg/stats.c
@@ -30,7 +30,7 @@
 PG_REGISTER_WITH_RESET_TEMPLATE(statsConfig_t, statsConfig, PG_STATS_CONFIG, 2);
 
 PG_RESET_TEMPLATE(statsConfig_t, statsConfig,
-    .stats_min_armed_time_s = STATS_OFF,
+    .stats_min_armed_time_s = 15,
     .stats_total_flights = 0,
     .stats_total_time_s = 0,
     .stats_total_dist_m = 0,


### PR DESCRIPTION
This PR enables flight stats by default.

<img width="440" height="123" alt="image" src="https://github.com/user-attachments/assets/4bf18511-3692-4dab-9a18-f562049758b4" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Default minimum armed-time threshold for statistics collection changed to 15 seconds.

* **Documentation**
  * Updated Defaults documentation to reflect the 15-second default for stats minimum armed-time.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rotorflight/rotorflight-firmware/pull/460)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->