### PR TITLE
Add FrSKY RPM and temperature sensor

### DIFF
--- a/src/main/drivers/fbus_sensor.c
+++ b/src/main/drivers/fbus_sensor.c
@@ -258,6 +258,13 @@ static fbusDetectedSensorType_e classifySensorTypeByAppId(uint16_t appId)
         return FBUS_DETECTED_SENSOR_FAS_150S;
     }
 
+    // FrSKY RPM S.PORT sensor https://www.frsky-rc.com/product/rpm/
+    if ((appId >= FBUS_RPM_TEMP1_BASE && appId <= (FBUS_RPM_TEMP1_BASE + 0x0F)) ||
+        (appId >= FBUS_RPM_TEMP2_BASE && appId <= (FBUS_RPM_TEMP2_BASE + 0x0F)) ||
+        (appId >= FBUS_RPM_BASE && appId <= (FBUS_RPM_BASE + 0x0F))) {
+        return FBUS_DETECTED_SENSOR_RPM;
+    }
+
     return FBUS_DETECTED_SENSOR_UNKNOWN;
 }
 
@@ -585,7 +592,7 @@ bool fbusSensorProcessDataWithSource(uint8_t physicalId, uint16_t appId, uint32_
         // ESC_R&C 0x0B60~0x0B6F:
         // bits 0..15 ERPM, bits 16..31 consumption (mAh)
         if (appId >= FBUS_ESC_RPM_CONS_BASE && appId <= (FBUS_ESC_RPM_CONS_BASE + 0x0F)) {
-            fbusEsc.erpm = (uint16_t)(data & 0xFFFFU);
+            fbusEsc.erpm = (uint32_t)(data & 0xFFFFU);
             fbusEsc.consumptionMah = (uint16_t)((data >> 16) & 0xFFFFU);
             fbusEsc.hasRpmConsumption = true;
             fbusEsc.lastUpdateUs = currentTimeUs;
@@ -601,6 +608,29 @@ bool fbusSensorProcessDataWithSource(uint8_t physicalId, uint16_t appId, uint32_
             return true;
         }
 
+        return false;
+    }
+
+    if (detectedType == FBUS_DETECTED_SENSOR_RPM) {
+        if (appId >= FBUS_RPM_TEMP1_BASE && appId <= (FBUS_RPM_TEMP1_BASE + 0x0F)) {
+            fbusEsc.temperatureDegC = (uint8_t)(data & 0xFFU);
+            fbusEsc.hasTemperature = true;
+            fbusEsc.lastUpdateUs = currentTimeUs;
+            return true;
+        }
+        if (appId >= FBUS_RPM_TEMP2_BASE && appId <= (FBUS_RPM_TEMP2_BASE + 0x0F)) {
+            fbusEsc.temperature2DegC = (uint8_t)(data & 0xFFU);
+            fbusEsc.hasTemperature = true;
+            fbusEsc.lastUpdateUs = currentTimeUs;
+            return true;
+        }
+        if (appId >= FBUS_RPM_BASE && appId <= (FBUS_RPM_BASE + 0x0F)) {
+            // Sensor goes as high as 300k RPM, we need 19 bits for that.
+            fbusEsc.erpm = (uint32_t)(data & 0x7FFFFU);
+            fbusEsc.hasRpmConsumption = true;
+            fbusEsc.lastUpdateUs = currentTimeUs;
+            return true;
+        }
         return false;
     }
     

--- a/src/main/drivers/fbus_sensor.c
+++ b/src/main/drivers/fbus_sensor.c
@@ -594,7 +594,8 @@ bool fbusSensorProcessDataWithSource(uint8_t physicalId, uint16_t appId, uint32_
         if (appId >= FBUS_ESC_RPM_CONS_BASE && appId <= (FBUS_ESC_RPM_CONS_BASE + 0x0F)) {
             fbusEsc.erpm = (uint32_t)(data & 0xFFFFU);
             fbusEsc.consumptionMah = (uint16_t)((data >> 16) & 0xFFFFU);
-            fbusEsc.hasRpmConsumption = true;
+            fbusEsc.hasRpm = true;
+            fbusEsc.hasConsumption = true;
             fbusEsc.lastUpdateUs = currentTimeUs;
             return true;
         }
@@ -627,7 +628,7 @@ bool fbusSensorProcessDataWithSource(uint8_t physicalId, uint16_t appId, uint32_
         if (appId >= FBUS_RPM_BASE && appId <= (FBUS_RPM_BASE + 0x0F)) {
             // Sensor goes as high as 300k RPM, we need 19 bits for that.
             fbusEsc.erpm = (uint32_t)(data & 0x7FFFFU);
-            fbusEsc.hasRpmConsumption = true;
+            fbusEsc.hasRpm = true;
             fbusEsc.lastUpdateUs = currentTimeUs;
             return true;
         }
@@ -678,7 +679,8 @@ void fbusSensorUpdate(timeUs_t currentTimeUs)
 
     if (fbusEsc.lastUpdateUs > 0 && (currentTimeUs - fbusEsc.lastUpdateUs) > 1000000) {
         fbusEsc.hasPower = false;
-        fbusEsc.hasRpmConsumption = false;
+        fbusEsc.hasRpm = false;
+        fbusEsc.hasConsumption = false;
         fbusEsc.hasTemperature = false;
     }
 
@@ -820,7 +822,7 @@ bool fbusSensorHasEscData(void)
 {
     timeUs_t currentTimeUs = micros();
 
-    if ((fbusEsc.hasPower || fbusEsc.hasRpmConsumption || fbusEsc.hasTemperature)
+    if ((fbusEsc.hasPower || fbusEsc.hasRpm || fbusEsc.hasConsumption || fbusEsc.hasTemperature )
         && fbusEsc.lastUpdateUs > 0) {
         if ((currentTimeUs - fbusEsc.lastUpdateUs) < 1000000) {
             return true;
@@ -864,6 +866,8 @@ const char* fbusSensorGetName(uint8_t physicalId)
                 return "FLVSS";
             case FBUS_DETECTED_SENSOR_XACT_SERVO:
                 return "XACT_SERVO";
+            case FBUS_DETECTED_SENSOR_RPM:
+                return "RPM";
             case FBUS_DETECTED_SENSOR_UNKNOWN:
             default:
                 break;

--- a/src/main/drivers/fbus_sensor.h
+++ b/src/main/drivers/fbus_sensor.h
@@ -194,7 +194,8 @@ typedef struct {
     uint8_t temperatureDegC;         // Temperature in C from 0x0B70~0x0B7F (bits 0..7)
     uint8_t temperature2DegC;         // Temperature in C from 0x0B70~0x0B7F (bits 0..7)
     bool hasPower;
-    bool hasRpmConsumption;
+    bool hasRpm;
+    bool hasConsumption;
     bool hasTemperature;
     timeUs_t lastUpdateUs;
 } fbusEscData_t;

--- a/src/main/drivers/fbus_sensor.h
+++ b/src/main/drivers/fbus_sensor.h
@@ -99,6 +99,14 @@ typedef enum {
 #define FBUS_SERVO_VOLTAGE_MASK     0x0000FF00  // Bits 8-15: Voltage (0.1V, 0~25.5V)
 #define FBUS_SERVO_TEMP_MASK        0x00FF0000  // Bits 16-23: Temperature (1°C, 0~255°C)
 
+// FrSKY RPM S.PORT sensor https://www.frsky-rc.com/product/rpm/
+typedef enum {
+    FBUS_RPM_TEMP1_BASE         = 0x0400,  // 0x0400~0x040F, Temperature
+    FBUS_RPM_TEMP2_BASE         = 0x0410,  // 0x0410~0x041F, Temperature
+    FBUS_RPM_BASE               = 0x0500,  // 0x0500~0x050F, RPM Sensor
+} fbusRpmDataId_e;
+
+
 // FBUS Sensor data structure
 typedef struct {
     uint8_t physicalId;
@@ -181,9 +189,10 @@ typedef struct {
 typedef struct {
     uint16_t voltageCentiVolts;      // Voltage in 0.01V from 0x0B50~0x0B5F (bits 0..15)
     uint16_t currentCentiAmps;       // Current in 0.01A from 0x0B50~0x0B5F (bits 16..31)
-    uint16_t erpm;                   // ERPM from 0x0B60~0x0B6F (bits 0..15)
+    uint32_t erpm;                   // ERPM from 0x0B60~0x0B6F (bits 0..15)
     uint16_t consumptionMah;         // Consumption in mAh from 0x0B60~0x0B6F (bits 16..31)
     uint8_t temperatureDegC;         // Temperature in C from 0x0B70~0x0B7F (bits 0..7)
+    uint8_t temperature2DegC;         // Temperature in C from 0x0B70~0x0B7F (bits 0..7)
     bool hasPower;
     bool hasRpmConsumption;
     bool hasTemperature;
@@ -227,6 +236,7 @@ typedef enum {
     FBUS_DETECTED_SENSOR_FAS_150S,
     FBUS_DETECTED_SENSOR_FLVSS,
     FBUS_DETECTED_SENSOR_XACT_SERVO,
+    FBUS_DETECTED_SENSOR_RPM,
 } fbusDetectedSensorType_e;
 
 typedef enum {

--- a/src/main/sensors/esc_sensor.c
+++ b/src/main/sensors/esc_sensor.c
@@ -309,6 +309,7 @@ static bool getFbusCombinedEscSensorData(escSensorData_t *escData)
         escData->id = FBUS_SENSOR_ESC;
         // FBUS temperature is in C, escSensorData uses 0.1C.
         escData->temperature = (int16_t)fbusEscData.temperatureDegC * 10;
+        escData->temperature2 = (int16_t)fbusEscData.temperature2DegC * 10;
     }
 
     return true;

--- a/src/main/sensors/esc_sensor.c
+++ b/src/main/sensors/esc_sensor.c
@@ -299,9 +299,13 @@ static bool getFbusCombinedEscSensorData(escSensorData_t *escData)
         }
     }
 
-    if (hasEscData && fbusEscData.hasRpmConsumption) {
+    if (hasEscData && fbusEscData.hasRpm) {
         escData->id = FBUS_SENSOR_ESC;
         escData->erpm = fbusEscData.erpm;
+    }
+
+    if (hasEscData && fbusEscData.hasConsumption) {
+        escData->id = FBUS_SENSOR_ESC;
         escData->consumption = applyConsumptionCorrection(fbusEscData.consumptionMah);
     }
 


### PR DESCRIPTION
I have a few if these old FrSKY sensors, would be convenient to use for measuring nitro head temperature.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic detection and support for FrSky RPM S.Port sensors.
  * Dual-temperature monitoring for ESCs (temperature1 and temperature2) now displayed.

* **Improvements**
  * RPM values decoded with extended range for very high RPMs (more accurate reporting).
  * RPM and consumption are reported independently, improving telemetry clarity and liveness handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rotorflight/rotorflight-firmware/pull/461)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->