### PR TITLE
drivers: add PY25Q128HA flash ID

### DIFF
--- a/src/main/drivers/flash_m25p16.c
+++ b/src/main/drivers/flash_m25p16.c
@@ -109,6 +109,9 @@ struct {
     // Winbond W25Q128
     // Datasheet: https://www.winbond.com/resource-files/w25q128fv%20rev.l%2008242015.pdf
     { 0xEF4018, 104, 50, 256, 256, &w25q_vTable },
+    // PUYA PY25Q128HA
+    // Datasheet: https://www.puyasemi.com/download_path/%E6%95%B0%E6%8D%AE%E6%89%8B%E5%86%8C/Flash%20%E8%8A%AF%E7%89%87/PY25Q128HA_Datasheet_V1.9.pdf
+    { 0x852018, 133, 80, 256, 256, &m25p16_vTable },
     // Zbit ZB25VQ128
     // Datasheet: http://zbitsemi.com/upload/file/20201010/20201010174048_82182.pdf
     { 0x5E4018, 104, 50, 256, 256, &m25p16_vTable },

--- a/src/main/drivers/flash_m25p16.c
+++ b/src/main/drivers/flash_m25p16.c
@@ -111,7 +111,7 @@ struct {
     { 0xEF4018, 104, 50, 256, 256, &w25q_vTable },
     // PUYA PY25Q128HA
     // Datasheet: https://www.puyasemi.com/download_path/%E6%95%B0%E6%8D%AE%E6%89%8B%E5%86%8C/Flash%20%E8%8A%AF%E7%89%87/PY25Q128HA_Datasheet_V1.9.pdf
-    { 0x852018, 133, 80, 256, 256, &m25p16_vTable },
+    { 0x852018, 133, 80, 256, 256, &w25q_vTable },
     // Zbit ZB25VQ128
     // Datasheet: http://zbitsemi.com/upload/file/20201010/20201010174048_82182.pdf
     { 0x5E4018, 104, 50, 256, 256, &m25p16_vTable },


### PR DESCRIPTION
Add support for PUYA PY25Q128 flash chips (used on BETAFPV F405 board)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the PUYA PY25Q128HA SPI NOR flash device.
  * Enables compatibility and reliable detection/operation with systems using this flash component, improving out-of-the-box support for hardware that includes this memory.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rotorflight/rotorflight-firmware/pull/462?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->