### PR TITLE
Workaround the problem with inital glitch when servo speed is set.

### DIFF
--- a/src/main/flight/servos.c
+++ b/src/main/flight/servos.c
@@ -58,6 +58,8 @@ static FAST_DATA_ZERO_INIT int16_t      servoOverride[MAX_SUPPORTED_SERVOS];
 
 static FAST_DATA_ZERO_INIT timerChannel_t servoChannel[MAX_SUPPORTED_SERVOS];
 
+static FAST_DATA_ZERO_INIT bool         servoInputSet[MAX_SUPPORTED_SERVOS];
+
 
 uint8_t getServoCount(void)
 {
@@ -315,7 +317,7 @@ void servoUpdate(void)
         const servoParam_t *servo = servoParams(i);
         float pos = input[i];
 
-        if (servo->speed > 0) {
+        if (servo->speed > 0 && servoInputSet[i]) {
             if (mixerIsCyclicServo(i))
                 pos = limitRatio(servoInput[i], pos, cyclic_ratio);
             else
@@ -323,6 +325,7 @@ void servoUpdate(void)
         }
 
         servoInput[i] = pos;
+        servoInputSet[i] = true;
 
         if (servo->flags & SERVO_FLAG_REVERSED)
             pos = -pos;


### PR DESCRIPTION
Fix, or rather workaround, the problem by skipping the first servo command instance where starting point for slow movement is set at default mid-point. On subsequent commands, starting point will be more correctly the current servo position. This is however not the real true servo position, as that position can not be read back from a PWM servo. So there are still a case where for example the servo and user Tx switch positions are not in sync at power on, then the servo will slam at full speed to the switch position. Still better than always slamming to center, regardless of switch position. If only the user is careful to check switch positions at craft power on, no glitching will occur. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved servo initialization behavior by removing artificial speed constraints on the first computed servo position calculation for each channel.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rotorflight/rotorflight-firmware/pull/466?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->