### PR TITLE
Fix IBUS2 channel decoding by requesting channel-type table

### DIFF
--- a/src/main/rx/ibus2_telemetry.c
+++ b/src/main/rx/ibus2_telemetry.c
@@ -64,6 +64,8 @@
 #define IBUS2_RESPONSE_DELAY_US                160
 #define IBUS_TEMPERATURE_OFFSET                400
 
+#define IBUS2_DEVICE_FLAG_CHANNELS_TYPES        (1 << 0)
+
 typedef enum {
     IBUS2_CMD_RESET = 0,
     IBUS2_CMD_GET_TYPE = 1,
@@ -478,7 +480,7 @@ static void ibus2SendGetTypeResponse(uint8_t address)
     if (address == IBUS2_HUB_ADDRESS || ibus2GetDeviceIndexForAddress(address) >= 0) {
         payload[0] = deviceType;
         payload[1] = valueLength;
-        payload[2] = 0;
+        payload[2] = (address == IBUS2_HUB_ADDRESS) ? IBUS2_DEVICE_FLAG_CHANNELS_TYPES : 0;
         ibus2SendResponse(IBUS2_CMD_GET_TYPE, payload, sizeof(payload));
     }
 }


### PR DESCRIPTION
## Summary
- ibus2SendGetTypeResponse() always reported ChannelsTypes=0 in the GET_TYPE reply, so the FlySky AFHDS3 receiver never sent the PacketSubtype=1 channel-type table.
- Without that table, haveChannelTypes stayed false and channel data fell back to a flat 12-bit decoder, which is structurally incompatible with the receiver's variable-bit-width "compressed channel data" frames, causing large jumps on all channels.
- Now the hub address response sets the ChannelsTypes bit, so the receiver sends the type table and the firmware uses the correct SES_UnpackChannels decode path.

## Test plan
- [x] Confirmed on real hardware (FlySky AFHDS3 receiver) that channel jumps are resolved after this fix
- [x] make TARGET=STM32F7X2 builds successfully


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved IBUS2 hub device address handling and response payload accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->