### PR TITLE
fix: adjusted servo max

### DIFF
--- a/src/main/flight/servos.c
+++ b/src/main/flight/servos.c
@@ -110,7 +110,7 @@ void validateAndFixServoConfig(void)
         volatile servoParam_t *servo = servoParamsMutable(i);
         const bool isBusServo = (i >= BUS_SERVO_OFFSET);
         const uint16_t minSignal = isBusServo ? BUS_SERVO_MIN_SIGNAL : PWM_SERVO_PULSE_MIN;
-        const uint16_t maxSignal = isBusServo ? BUS_SERVO_MAX_SIGNAL : PWM_SERVO_PULSE_MAX;
+        const uint16_t maxSignal = isBusServo ? BUS_SERVO_MAX_SIGNAL : PWM_SERVO_PULSE_MAX + PWM_RANGE;
         
 #ifndef USE_SERVO_GEOMETRY_CORRECTION
         servo->flags &= ~SERVO_FLAG_GEO_CORR;

--- a/src/main/rx/rx.h
+++ b/src/main/rx/rx.h
@@ -45,7 +45,7 @@
 #define PWM_PULSE_MAX           2250      // maximum PWM pulse width which is considered valid
 
 #define PWM_SERVO_PULSE_MIN     50        // minimum PWM servo output pulse width allowed
-#define PWM_SERVO_PULSE_MAX     3000      // maximum PWM servo output pulse width allowed
+#define PWM_SERVO_PULSE_MAX     2250      // maximum PWM servo output pulse width allowed
 
 #define RXFAIL_PULSE_MIN        875
 #define RXFAIL_PULSE_MAX        2150

--- a/src/main/rx/rx.h
+++ b/src/main/rx/rx.h
@@ -45,7 +45,7 @@
 #define PWM_PULSE_MAX           2250      // maximum PWM pulse width which is considered valid
 
 #define PWM_SERVO_PULSE_MIN     50        // minimum PWM servo output pulse width allowed
-#define PWM_SERVO_PULSE_MAX     2250      // maximum PWM servo output pulse width allowed
+#define PWM_SERVO_PULSE_MAX     3000      // maximum PWM servo output pulse width allowed
 
 #define RXFAIL_PULSE_MIN        875
 #define RXFAIL_PULSE_MAX        2150


### PR DESCRIPTION
Currently the max PWM servo pulse is limited to 2250 µs. However, there are servos that support longer pulses. This fix adjust the max PWM pulse to 3250 µs. 

<img width="1632" height="778" alt="image" src="https://github.com/user-attachments/assets/010c1d6d-6d7c-477f-a353-3f04e56eda0e" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Expanded servo signal range constraints to support wider pulse configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->