### PR TITLE
Change servo PWM pulse maximum to 2500us

### DIFF
--- a/src/main/rx/rx.h
+++ b/src/main/rx/rx.h
@@ -45,7 +45,7 @@
 #define PWM_PULSE_MAX           2250      // maximum PWM pulse width which is considered valid
 
 #define PWM_SERVO_PULSE_MIN     50        // minimum PWM servo output pulse width allowed
-#define PWM_SERVO_PULSE_MAX     2250      // maximum PWM servo output pulse width allowed
+#define PWM_SERVO_PULSE_MAX     2500      // maximum PWM servo output pulse width allowed
 
 #define RXFAIL_PULSE_MIN        875
 #define RXFAIL_PULSE_MAX        2150


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Increased the maximum allowed servo PWM pulse width, expanding supported output range for compatible hardware.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->