### PR TITLE
feat: Fix blackbox serial buffering and UART driver blocking logic

### DIFF
--- a/src/main/blackbox/blackbox.c
+++ b/src/main/blackbox/blackbox.c
@@ -2042,6 +2042,8 @@ void blackboxUpdate(timeUs_t currentTimeUs)
 {
     static BlackboxState cacheFlushNextState;
 
+    blackboxBeginWrite();
+
     blackboxCheckEnabler(currentTimeUs);
 
     if (IS_RC_MODE_ACTIVE(BOXBLACKBOXERASE) &&
@@ -2237,6 +2239,8 @@ void blackboxUpdate(timeUs_t currentTimeUs)
             blackboxSetState(BLACKBOX_STATE_FULL);
         }
     }
+
+    blackboxEndWrite();
 }
 
 uint8_t blackboxGetRateDenom(void)

--- a/src/main/blackbox/blackbox_io.c
+++ b/src/main/blackbox/blackbox_io.c
@@ -61,9 +61,16 @@
 
 #define BLACKBOX_SERIAL_PORT_MODE MODE_TX
 
-uint8_t bbSerialBuffer[BLACKBOX_SERIAL_BUFFER_SIZE];
-uint32_t bbSerialBufferLen = 0;
-bool bbIsSerialBufferActive = false;
+/*
+ * There are ~145 main fields. In the absolute mathematical worst-case where every single field
+ * generates a 32-bit max integer, Variable Byte encoding uses 5 bytes per field.
+ * 145 * 5 = 725 bytes theoretical max. So 1024 is the safest compile-time boundary.
+ */
+#define BLACKBOX_SERIAL_BUFFER_SIZE 1024
+
+static uint8_t bbSerialBuffer[BLACKBOX_SERIAL_BUFFER_SIZE];
+static uint32_t bbSerialBufferLen = 0;
+static bool bbIsSerialBufferActive = false;
 
 // How many bytes can we transmit per loop iteration when writing headers?
 static uint8_t blackboxMaxHeaderBytesPerIteration;

--- a/src/main/blackbox/blackbox_io.c
+++ b/src/main/blackbox/blackbox_io.c
@@ -484,6 +484,10 @@ void blackboxDeviceClose(void)
     switch (blackboxConfig()->device) {
     case BLACKBOX_DEVICE_SERIAL:
         // Can immediately close without attempting to flush any remaining data.
+        if (bbIsSerialBufferActive) {
+            serialEndWrite(blackboxPort);
+            bbIsSerialBufferActive = false;
+        }
         // Since the serial port could be shared with other processes, we have to give it back here
         closeSerialPort(blackboxPort);
         blackboxPort = NULL;

--- a/src/main/blackbox/blackbox_io.c
+++ b/src/main/blackbox/blackbox_io.c
@@ -61,6 +61,10 @@
 
 #define BLACKBOX_SERIAL_PORT_MODE MODE_TX
 
+uint8_t bbSerialBuffer[BLACKBOX_SERIAL_BUFFER_SIZE];
+uint32_t bbSerialBufferLen = 0;
+bool bbIsSerialBufferActive = false;
+
 // How many bytes can we transmit per loop iteration when writing headers?
 static uint8_t blackboxMaxHeaderBytesPerIteration;
 
@@ -106,9 +110,89 @@ static uint32_t bbBits;
 static timeMs_t bbLastclearMs;
 static uint16_t bbRateMax;
 static uint32_t bbDrops;
+
+static void blackboxUpdateDebugRate(void)
+{
+    timeMs_t now = millis();
+    if (now > bbLastclearMs + 100) {  // Debug log every 100[msec]
+        uint16_t bbRate = ((bbBits * 10 + 5) / (now - bbLastclearMs)) / 10; // In unit of [Kbps]
+        DEBUG_SET(DEBUG_BLACKBOX_OUTPUT, 0, bbRate);
+        if (bbRate > bbRateMax) {
+            bbRateMax = bbRate;
+            DEBUG_SET(DEBUG_BLACKBOX_OUTPUT, 1, bbRateMax);
+        }
+        bbLastclearMs = now;
+        bbBits = 0;
+    }
+}
 #endif
 
+void blackboxBeginWrite(void)
+{
+    if (blackboxPort) {
+        bbIsSerialBufferActive = true;
+        serialBeginWrite(blackboxPort);
+        bbSerialBufferLen = 0;
+    }
+}
+
+static void flushSerialBuffer(void)
+{
+    if (bbSerialBufferLen == 0) {
+        return;
+    }
+
+#ifdef DEBUG_BB_OUTPUT
+    DEBUG_TIME_START(BLACKBOX_OUTPUT, 4);
+#endif
+
+    uint32_t txBytesFree = serialTxBytesFree(blackboxPort);
+#ifdef DEBUG_BB_OUTPUT
+    DEBUG_SET(DEBUG_BLACKBOX_OUTPUT, 3, txBytesFree);
+    bbBits += (bbSerialBufferLen * 8);
+#endif
+
+    uint32_t bytesToWrite = txBytesFree < bbSerialBufferLen ? txBytesFree : bbSerialBufferLen;
+
+    if (bytesToWrite > 0) {
+        serialWriteBuf(blackboxPort, bbSerialBuffer, bytesToWrite);
+    }
+
+#ifdef DEBUG_BB_OUTPUT
+    if (bbSerialBufferLen > bytesToWrite) {
+        bbDrops += (bbSerialBufferLen - bytesToWrite);
+        DEBUG_SET(DEBUG_BLACKBOX_OUTPUT, 2, bbDrops);
+    }
+    // Record the time spent pushing data to the UART
+    DEBUG_TIME_END(BLACKBOX_OUTPUT, 4);
+
+    // We only update debug rate when flushing to limit overhead
+    blackboxUpdateDebugRate();
+#endif
+    bbSerialBufferLen = 0;
+}
+
+void blackboxEndWrite(void)
+{
+    if (blackboxPort) {
+        flushSerialBuffer();
+        serialEndWrite(blackboxPort);
+        bbIsSerialBufferActive = false;
+    }
+}
+
 void blackboxWrite(uint8_t value)
+{
+    if (bbIsSerialBufferActive) {
+        if (bbSerialBufferLen < BLACKBOX_SERIAL_BUFFER_SIZE) {
+            bbSerialBuffer[bbSerialBufferLen++] = value;
+        }
+    } else {
+        blackboxWriteUnbuffered(value);
+    }
+}
+
+void blackboxWriteUnbuffered(uint8_t value)
 {
 #ifdef DEBUG_BB_OUTPUT
     bbBits += 8;
@@ -148,18 +232,7 @@ void blackboxWrite(uint8_t value)
     }
 
 #ifdef DEBUG_BB_OUTPUT
-    timeMs_t now = millis();
-
-    if (now > bbLastclearMs + 100) {  // Debug log every 100[msec]
-        uint16_t bbRate = ((bbBits * 10 + 5) / (now - bbLastclearMs)) / 10; // In unit of [Kbps]
-        DEBUG_SET(DEBUG_BLACKBOX_OUTPUT, 0, bbRate);
-        if (bbRate > bbRateMax) {
-            bbRateMax = bbRate;
-            DEBUG_SET(DEBUG_BLACKBOX_OUTPUT, 1, bbRateMax);
-        }
-        bbLastclearMs = now;
-        bbBits = 0;
-    }
+    blackboxUpdateDebugRate();
 #endif
 }
 

--- a/src/main/blackbox/blackbox_io.h
+++ b/src/main/blackbox/blackbox_io.h
@@ -40,8 +40,21 @@ typedef enum {
 
 extern int32_t blackboxHeaderBudget;
 
+/*
+ * There are ~145 main fields. In the absolute mathematical worst-case where every single field 
+ * generates a 32-bit max integer, Variable Byte encoding uses 5 bytes per field. 
+ * 145 * 5 = 725 bytes theoretical max. So 1024 is the safest compile-time boundary.
+ */
+#define BLACKBOX_SERIAL_BUFFER_SIZE 1024
+extern uint8_t bbSerialBuffer[BLACKBOX_SERIAL_BUFFER_SIZE];
+extern uint32_t bbSerialBufferLen;
+extern bool bbIsSerialBufferActive;
+
 void blackboxOpen(void);
+void blackboxBeginWrite(void);
+void blackboxEndWrite(void);
 void blackboxWrite(uint8_t value);
+void blackboxWriteUnbuffered(uint8_t value);
 int blackboxWriteString(const char *s);
 
 void blackboxDeviceFlush(void);

--- a/src/main/blackbox/blackbox_io.h
+++ b/src/main/blackbox/blackbox_io.h
@@ -40,16 +40,6 @@ typedef enum {
 
 extern int32_t blackboxHeaderBudget;
 
-/*
- * There are ~145 main fields. In the absolute mathematical worst-case where every single field 
- * generates a 32-bit max integer, Variable Byte encoding uses 5 bytes per field. 
- * 145 * 5 = 725 bytes theoretical max. So 1024 is the safest compile-time boundary.
- */
-#define BLACKBOX_SERIAL_BUFFER_SIZE 1024
-extern uint8_t bbSerialBuffer[BLACKBOX_SERIAL_BUFFER_SIZE];
-extern uint32_t bbSerialBufferLen;
-extern bool bbIsSerialBufferActive;
-
 void blackboxOpen(void);
 void blackboxBeginWrite(void);
 void blackboxEndWrite(void);

--- a/src/main/drivers/serial_uart.c
+++ b/src/main/drivers/serial_uart.c
@@ -324,8 +324,8 @@ static void uartWriteBuf(serialPort_t *instance, const void *data, int count)
 
         if (freeSpace == 0) {
             // Start hardware and spin infinitely until space is available.
-            // That alignes with old fallback implementation but could lead to a locked FC 
-            // if hardware fails to drain data for whatever reason! 
+            // That aligns with old fallback implementation but could lead to a locked FC
+            // if hardware fails to drain data for whatever reason!
             uartStartTxHardware(uartPort);
             while ((freeSpace = uartTotalTxBytesFree(instance)) == 0) {
                 // Spin

--- a/src/main/drivers/serial_uart.c
+++ b/src/main/drivers/serial_uart.c
@@ -35,6 +35,7 @@
 #include "build/build_config.h"
 
 #include "common/utils.h"
+#include "drivers/time.h"
 
 #include "drivers/dma.h"
 #include "drivers/dma_reqmap.h"
@@ -265,18 +266,8 @@ static uint8_t uartRead(serialPort_t *instance)
     return ch;
 }
 
-static void uartWrite(serialPort_t *instance, uint8_t ch)
+static void uartStartTxHardware(uartPort_t *uartPort)
 {
-    uartPort_t *uartPort = (uartPort_t *)instance;
-
-    uartPort->port.txBuffer[uartPort->port.txBufferHead] = ch;
-
-    if (uartPort->port.txBufferHead + 1 >= uartPort->port.txBufferSize) {
-        uartPort->port.txBufferHead = 0;
-    } else {
-        uartPort->port.txBufferHead++;
-    }
-
 #ifdef USE_DMA
     if (uartPort->txDMAResource) {
         uartTryStartTxDMA(uartPort);
@@ -291,6 +282,99 @@ static void uartWrite(serialPort_t *instance, uint8_t ch)
     }
 }
 
+static void uartDisableTxInterrupts(uartPort_t *uartPort)
+{
+#ifdef USE_DMA
+    if (!uartPort->txDMAResource)
+#endif
+    {
+#ifdef USE_HAL_DRIVER
+        __HAL_UART_DISABLE_IT(&uartPort->Handle, UART_IT_TXE);
+#else
+        USART_ITConfig(uartPort->USARTx, USART_IT_TXE, DISABLE);
+#endif
+    }
+}
+
+static void uartWrite(serialPort_t *instance, uint8_t ch)
+{
+    uartPort_t *uartPort = (uartPort_t *)instance;
+
+    uartPort->port.txBuffer[uartPort->port.txBufferHead] = ch;
+
+    if (uartPort->port.txBufferHead + 1 >= uartPort->port.txBufferSize) {
+        uartPort->port.txBufferHead = 0;
+    } else {
+        uartPort->port.txBufferHead++;
+    }
+
+    if (!uartPort->isBulkWrite) {
+        uartStartTxHardware(uartPort);
+    }
+}
+
+static void uartWriteBuf(serialPort_t *instance, const void *data, int count)
+{
+    uartPort_t *uartPort = (uartPort_t *)instance;
+    const uint8_t *p = (const uint8_t *)data;
+    int txBufferSize = uartPort->port.txBufferSize;
+
+    while (count > 0) {
+        int freeSpace = uartTotalTxBytesFree(instance);
+
+        if (freeSpace == 0) {
+            // Start hardware and spin infinitely until space is available.
+            // That alignes with old fallback implementation but could lead to a locked FC 
+            // if hardware fails to drain data for whatever reason! 
+            uartStartTxHardware(uartPort);
+            while ((freeSpace = uartTotalTxBytesFree(instance)) == 0) {
+                // Spin
+            }
+        }
+
+        int txBufferHead = uartPort->port.txBufferHead;
+        int spaceUntilWrap = txBufferSize - txBufferHead;
+        
+        // We can only copy up to what's free, AND what's contiguous before the buffer wraps
+        int chunk = count;
+        if (chunk > freeSpace) {
+            chunk = freeSpace;
+        }
+        if (chunk > spaceUntilWrap) {
+            chunk = spaceUntilWrap;
+        }
+        
+        memcpy((void *)&uartPort->port.txBuffer[txBufferHead], p, chunk);
+        
+        txBufferHead += chunk;
+        if (txBufferHead >= txBufferSize) {
+            txBufferHead = 0;
+        }
+        uartPort->port.txBufferHead = txBufferHead;
+        
+        p += chunk;
+        count -= chunk;
+    }
+
+    if (!uartPort->isBulkWrite) {
+        uartStartTxHardware(uartPort);
+    }
+}
+
+static void uartBeginWrite(serialPort_t *instance)
+{
+    uartPort_t *uartPort = (uartPort_t *)instance;
+    uartPort->isBulkWrite = true;
+    uartDisableTxInterrupts(uartPort);
+}
+
+static void uartEndWrite(serialPort_t *instance)
+{
+    uartPort_t *uartPort = (uartPort_t *)instance;
+    uartPort->isBulkWrite = false;
+    uartStartTxHardware(uartPort);
+}
+
 const struct serialPortVTable uartVTable[] = {
     {
         .serialWrite = uartWrite,
@@ -302,9 +386,9 @@ const struct serialPortVTable uartVTable[] = {
         .setMode = uartSetMode,
         .setCtrlLineStateCb = NULL,
         .setBaudRateCb = NULL,
-        .writeBuf = NULL,
-        .beginWrite = NULL,
-        .endWrite = NULL,
+        .writeBuf = uartWriteBuf,
+        .beginWrite = uartBeginWrite,
+        .endWrite = uartEndWrite,
     }
 };
 

--- a/src/main/drivers/serial_uart.h
+++ b/src/main/drivers/serial_uart.h
@@ -72,6 +72,7 @@ typedef struct uartPort_s {
 #endif
     USART_TypeDef *USARTx;
     bool txDMAEmpty;
+    bool isBulkWrite;
 } uartPort_t;
 
 void uartPinConfigure(const serialPinConfig_t *pSerialPinConfig);


### PR DESCRIPTION
This PR reduces the CPU load when using UART logging devices (OpenLager). 

Since I have touched the serial_uart, this needs careful testing, as it is not just a blackbox change. 

I have tested this on Nexus-XR/Nexus (no difference found) and on a FlyingRc F4 board with external logging. 
The main reason RT-Load is that "high" on that board is it is running an 8 kHz gyro loop which does not leave a lot of time for blackbox logging. However, I think (!) this implementation is better and should not make things worse :-)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added buffered serial output support for blackbox logging, including begin/end write handling and bulk write capability.
  * Improved UART transmission flow to better support larger data writes and reduce write overhead.

* **Bug Fixes**
  * Blackbox writes now use explicit write-session handling, helping ensure output is flushed more reliably.
  * Adjusted debug-rate reporting during blackbox output to keep counters and rate calculations consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->