### PR TITLE
 Allow old and new mode for XDFLY/ZTW/OMPHOBBY ESC telemetry

### DIFF
--- a/src/main/sensors/esc_sensor.c
+++ b/src/main/sensors/esc_sensor.c
@@ -4046,12 +4046,26 @@ static int8_t xdfly_accept(uint16_t c)
     return 0;
 }
 
-static serialReceiveCallbackPtr xdflySensorInit(uint8_t sig)
+static serialReceiveCallbackPtr xdflySensorInit(uint8_t sig, bool bidirectional)
 {
-    rrfsmCrank  = xdfly_crank_unc_setup;
+    rrfsmStart = NULL;
+    rrfsmCrank = bidirectional ? xdfly_crank_unc_setup : NULL;
     rrfsmDecode = xdfly_decode;
     rrfsmAccept = xdfly_accept;
-    paramCommit = xdfly_param_commit;
+    rrfsmBootDelayMs = 0;
+    rrfsmMinFrameLength = bidirectional ? 0 : XDFLY_HEADER_LENGTH;
+    rrfsmFrameTimestamp = 0;
+    rrfsmFramePeriod = 0;
+    rrfsmFrameTimeout = 0;
+    readBytes = 0;
+    reqLength = 0;
+    readIngoreBytes = 0;
+    syncCount = 0;
+    xdfly_setup_status = XDFLY_INIT;
+    xdfly_connected = false;
+    xdfly_send_handshake = false;
+    xdfly_handshake_response_pending = false;
+    paramCommit = bidirectional ? xdfly_param_commit : NULL;
     escSig = sig;
     return rrfsmDataReceive;
 }
@@ -4263,7 +4277,7 @@ void escSensorProcess(timeUs_t currentTimeUs)
                 break;
             case ESC_SENSOR_PROTO_XDFLY:
             case ESC_SENSOR_PROTO_ZTW:
-            case ESC_SENSOR_PROTO_OMPHOBBY:            
+            case ESC_SENSOR_PROTO_OMPHOBBY:
                 rrfsmSensorProcess(currentTimeUs);
                 break;
             case ESC_SENSOR_PROTO_FBUS:
@@ -4292,9 +4306,6 @@ void INIT_CODE validateAndFixEscSensorConfig(void)
 {
     switch (escSensorConfig()->protocol) {
         case ESC_SENSOR_PROTO_GRAUPNER:
-        case ESC_SENSOR_PROTO_XDFLY:
-        case ESC_SENSOR_PROTO_OMPHOBBY:
-        case ESC_SENSOR_PROTO_ZTW:     
             escSensorConfigMutable()->halfDuplex = true;
             break;
 #ifdef USE_TELEMETRY_CASTLE
@@ -4361,13 +4372,13 @@ bool INIT_CODE escSensorInit(void)
             options |= SERIAL_PARITY_EVEN;
             break;
         case ESC_SENSOR_PROTO_OMPHOBBY:
-            callback = xdflySensorInit(ESC_SIG_OMP);
+            callback = xdflySensorInit(ESC_SIG_OMP, escHalfDuplex);
             baudrate = 115200;
-            break;        
-         case ESC_SENSOR_PROTO_ZTW:
-            callback = xdflySensorInit(ESC_SIG_ZTW);
+            break;
+        case ESC_SENSOR_PROTO_ZTW:
+            callback = xdflySensorInit(ESC_SIG_ZTW, escHalfDuplex);
             baudrate = 115200;
-            break;    
+            break;
         case ESC_SENSOR_PROTO_APD:
             baudrate = 115200;
             break;
@@ -4388,7 +4399,7 @@ bool INIT_CODE escSensorInit(void)
             baudrate = 19200;
             break;
         case ESC_SENSOR_PROTO_XDFLY:
-            callback = xdflySensorInit(ESC_SIG_XDFLY);
+            callback = xdflySensorInit(ESC_SIG_XDFLY, escHalfDuplex);
             baudrate = 115200;
             break;
         case ESC_SENSOR_PROTO_RECORD:

--- a/src/main/sensors/esc_sensor.c
+++ b/src/main/sensors/esc_sensor.c
@@ -4292,11 +4292,6 @@ void INIT_CODE validateAndFixEscSensorConfig(void)
 {
     switch (escSensorConfig()->protocol) {
         case ESC_SENSOR_PROTO_GRAUPNER:
-        case ESC_SENSOR_PROTO_XDFLY:
-        case ESC_SENSOR_PROTO_OMPHOBBY:
-        case ESC_SENSOR_PROTO_ZTW:     
-            escSensorConfigMutable()->halfDuplex = true;
-            break;
 #ifdef USE_TELEMETRY_CASTLE
         case ESC_SENSOR_PROTO_NONE:
             if (isMotorProtocolCastlePWM()) {

--- a/src/main/sensors/esc_sensor.c
+++ b/src/main/sensors/esc_sensor.c
@@ -4292,6 +4292,11 @@ void INIT_CODE validateAndFixEscSensorConfig(void)
 {
     switch (escSensorConfig()->protocol) {
         case ESC_SENSOR_PROTO_GRAUPNER:
+        case ESC_SENSOR_PROTO_XDFLY:
+        case ESC_SENSOR_PROTO_OMPHOBBY:
+        case ESC_SENSOR_PROTO_ZTW:     
+            escSensorConfigMutable()->halfDuplex = true;
+            break;
 #ifdef USE_TELEMETRY_CASTLE
         case ESC_SENSOR_PROTO_NONE:
             if (isMotorProtocolCastlePWM()) {


### PR DESCRIPTION
**Summary**

Older XDFLY/ZTW/OMPHOBBY ESC firmware only broadcasts unsolicited telemetry frames and just needs a plain RX wire. Newer firmware additionally supports a bidirectional handshake for parameter read/write.

Previously halfDuplex was force-enabled for these three protocols in validateAndFixEscSensorConfig(), regardless of the user's setting, which required half-duplex-capable wiring even for old firmware that never uses it.

halfDuplex is now left under user control (esc_sensor_halfduplex) for XDFLY/ZTW/OMPHOBBY (still forced for GRAUPNER). xdflySensorInit() takes a bidirectional flag: when true, it behaves as before (handshake + parameter read/write); when false, it just passively decodes telemetry frames with no TX/handshake state machine.

**Testing**
Fix has been tested on old and new (un unpublished) ztw firmwares.   
Fix has been checked for good measure on xdfly firmware.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bidirectional ESC sensor initialization and request handling.
  * Updated protocol processing for improved compatibility with supported ESC telemetry protocols.
  * Corrected half-duplex configuration behavior for Graupner, XDFLY, OMPHobby, and ZTW protocols.
  * Improved parameter commit handling during sensor initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->