### PR TITLE
Add horizon angle limit configuration and update leveling logic

### DIFF
--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -1173,6 +1173,7 @@ const clivalue_t valueTable[] = {
     { "horizon_transition",         VAR_UINT8  | PROFILE_VALUE, .config.minmaxUnsigned = { 0, 200 }, PG_PID_PROFILE, offsetof(pidProfile_t, horizon.transition) },
     { "horizon_tilt_effect",        VAR_UINT8  | PROFILE_VALUE, .config.minmaxUnsigned = { 0,  250 }, PG_PID_PROFILE, offsetof(pidProfile_t, horizon.tilt_effect) },
     { "horizon_tilt_expert_mode",   VAR_UINT8  | PROFILE_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_PID_PROFILE, offsetof(pidProfile_t, horizon.tilt_expert_mode) },
+    { "horizon_angle_limit",        VAR_UINT8  | PROFILE_VALUE, .config.minmaxUnsigned = { 10, 90 }, PG_PID_PROFILE, offsetof(pidProfile_t, horizon.angle_limit) },
 
 #ifdef USE_ACRO_TRAINER
     { "acro_trainer_angle_limit",   VAR_UINT8  | PROFILE_VALUE, .config.minmaxUnsigned = { 10, 80 }, PG_PID_PROFILE, offsetof(pidProfile_t, trainer.angle_limit) },

--- a/src/main/flight/leveling.c
+++ b/src/main/flight/leveling.c
@@ -36,6 +36,8 @@
 #include "common/axis.h"
 #include "common/filter.h"
 
+#include "drivers/time.h"
+
 #include "fc/rc_rates.h"
 #include "fc/core.h"
 #include "fc/rc.h"
@@ -60,6 +62,7 @@ typedef struct {
     float Transition;
     float CutoffDegrees;
     float FactorRatio;
+    float AngleLimit;
     uint8_t TiltExpertMode;
 } horizon_t;
 
@@ -77,6 +80,7 @@ INIT_CODE void levelingInit(const pidProfile_t *pidProfile)
     horizon.TiltExpertMode = pidProfile->horizon.tilt_expert_mode;
     horizon.CutoffDegrees = (175 - pidProfile->horizon.tilt_effect) * 1.8f;
     horizon.FactorRatio = (100 - pidProfile->horizon.tilt_effect) * 0.01f;
+    horizon.AngleLimit = pidProfile->horizon.angle_limit;
 }
 
 int get_ADJUSTMENT_ANGLE_LEVEL_GAIN(void)
@@ -101,6 +105,27 @@ void set_ADJUSTMENT_HORIZON_LEVEL_GAIN(int value)
     horizon.Gain = value / 10.0f;
 }
 
+// Tracks when HORIZON_MODE was most recently activated; reset by levelingUpdate() when mode is off
+static uint32_t horizonActivationTimeMs = 0;
+#define HORIZON_ENGAGE_RAMP_MS  500.0f
+
+void levelingUpdate(void)
+{
+    if (!FLIGHT_MODE(HORIZON_MODE)) {
+        horizonActivationTimeMs = 0;
+    }
+}
+
+static float horizonActivationRamp(void)
+{
+    const uint32_t now = millis();
+    if (horizonActivationTimeMs == 0) {
+        horizonActivationTimeMs = now ? now : 1;
+        return 0.0f;
+    }
+    return constrainf((float)(now - horizonActivationTimeMs) / HORIZON_ENGAGE_RAMP_MS, 0.0f, 1.0f);
+}
+
 // calculate the stick deflection while applying level mode expo
 static inline float getLevelModeDeflection(uint8_t axis)
 {
@@ -114,15 +139,15 @@ static inline float getLevelModeDeflection(uint8_t axis)
     return deflection;
 }
 
-static float calcLevelErrorAngle(int axis)
+static float calcLevelErrorAngle(int axis, float angleLimit)
 {
     const rollAndPitchTrims_t *angleTrim = &accelerometerConfig()->accelerometerTrims;
-    float angle = level.AngleLimit * getLevelModeDeflection(axis);
+    float angle = angleLimit * getLevelModeDeflection(axis);
 
 #ifdef USE_GPS_RESCUE
     angle += gpsRescueAngle[axis] / 100.0f; // ANGLE IS IN CENTIDEGREES
 #endif
-    angle = constrainf(angle, -level.AngleLimit, level.AngleLimit);
+    angle = constrainf(angle, -angleLimit, angleLimit);
 
     float currentAngle = ((attitude.raw[axis] - angleTrim->raw[axis]) / 10.0f);
 
@@ -143,13 +168,16 @@ static float calcLevelErrorAngle(int axis)
 }
 
 // calculates strength of horizon leveling; 0 = none, 1.0 = most leveling
-static float calcHorizonLevelStrength(void)
+// Uses per-axis stick deflection with a cubic curve for a smoother feel near center.
+static float calcHorizonLevelStrength(int axis)
 {
-    // start with 1.0 at center stick, 0.0 at max stick deflection:
-    float horizonLevelStrength = 1.0f - fmaxf(fabsf(getLevelModeDeflection(FD_ROLL)), fabsf(getLevelModeDeflection(FD_PITCH)));
+    // Per-axis cubic mapping: 1.0 at center stick, 0.0 at full deflection.
+    // Cubic gives strong leveling near center with a smooth dropoff toward full throw.
+    const float deflection = fabsf(getLevelModeDeflection(axis));
+    float horizonLevelStrength = 1.0f - deflection * deflection * deflection;
 
     // 0 at level, 90 at vertical, 180 at inverted (degrees):
-    const float currentInclination = fmaxf(abs(attitude.values.roll), abs(attitude.values.pitch)) / 10.0f;
+    const float currentInclination = fmaxf(fabsf((float)attitude.values.roll), fabsf((float)attitude.values.pitch)) / 10.0f;
 
     // horizonTiltExpertMode:  0 = leveling always active when sticks centered,
     //                         1 = leveling can be totally off when inverted
@@ -206,7 +234,7 @@ float angleModeApply(int axis, float pidSetpoint)
 {
     if (axis == FD_ROLL || axis == FD_PITCH)
     {
-        float errorAngle = calcLevelErrorAngle(axis);
+        float errorAngle = calcLevelErrorAngle(axis, level.AngleLimit);
 
         if (!isAirborne())
             errorAngle *= 0.25f;
@@ -221,12 +249,12 @@ float horizonModeApply(int axis, float pidSetpoint)
 {
     if (axis == FD_ROLL || axis == FD_PITCH)
     {
-        float errorAngle = calcLevelErrorAngle(axis);
+        float errorAngle = calcLevelErrorAngle(axis, horizon.AngleLimit);
 
         if (!isAirborne())
             errorAngle *= 0.25f;
 
-        pidSetpoint += errorAngle * horizon.Gain * calcHorizonLevelStrength();
+        pidSetpoint += errorAngle * horizon.Gain * calcHorizonLevelStrength(axis) * horizonActivationRamp();
     }
 
     return pidSetpoint;

--- a/src/main/flight/leveling.h
+++ b/src/main/flight/leveling.h
@@ -28,6 +28,7 @@
 #include "pg/adjustments.h"
 
 void levelingInit(const pidProfile_t *pidProfile);
+void levelingUpdate(void);
 
 float angleModeApply(int axis, float pidSetpoint);
 float horizonModeApply(int axis, float pidSetpoint);

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -1701,6 +1701,9 @@ void pidController(const pidProfile_t *pidProfile, timeUs_t currentTimeUs)
     UNUSED(pidProfile);
     UNUSED(currentTimeUs);
 
+    // Update leveling mode state (resets horizon activation timer when mode is off)
+    levelingUpdate();
+
     // Rotate pitch/roll axis error with yaw rotation
     rotateAxisError();
 

--- a/src/main/pg/pid.c
+++ b/src/main/pg/pid.c
@@ -82,6 +82,7 @@ void resetPidProfile(pidProfile_t *pidProfile)
         .horizon.transition = 75,
         .horizon.tilt_effect = 75,
         .horizon.tilt_expert_mode = false,
+        .horizon.angle_limit = 55,
         .trainer.gain = 75,
         .trainer.angle_limit = 20,
         .trainer.lookahead_ms = 50,

--- a/src/main/pg/pid.h
+++ b/src/main/pg/pid.h
@@ -69,6 +69,7 @@ typedef struct {
     uint8_t transition;
     uint8_t tilt_effect;           // inclination factor for Horizon mode
     uint8_t tilt_expert_mode;      // OFF or ON
+    uint8_t angle_limit;           // Max angle in degrees in horizon mode
 } pidHorizonMode_t;
 
 typedef struct {


### PR DESCRIPTION
### New configuration parameter
- Adds `horizon_angle_limit` (range 10–90°, default 55°) to `pidHorizonMode_t` and exposes it as a CLI setting. Previously, Horizon mode silently reused the Angle mode's angle limit; now it has its own independent cap.

### Per-axis leveling strength (cubic curve)
- `calcHorizonLevelStrength()` now takes the current `axis` parameter instead of always using the worst-case of roll/pitch.
- The leveling falloff changes from a linear $1 - |\delta|$ to a cubic $1 - |\delta|^3$, giving stronger self-leveling near center stick with a smoother dropoff toward full throw.
- Also fixes a subtle cast issue: `abs()` (integer) replaced with `fabsf()` for the attitude inclination calculation.

### Engagement ramp
- Adds a 500 ms linear ramp (`HORIZON_ENGAGE_RAMP_MS`) when Horizon mode is first activated. The leveling correction starts at 0 and ramps to full strength over 500 ms, preventing a sudden jolt when the mode is switched on.
- `levelingUpdate()` (called every PID cycle from `pidController()`) resets the ramp timer when Horizon mode is not active.

### `calcLevelErrorAngle()` refactor
- Now accepts `angleLimit` as a parameter instead of always reading from `level.AngleLimit`, allowing Angle mode and Horizon mode to pass their own separate limits.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configurable Horizon mode angle limit, adjustable from 10–90 degrees.
  * Horizon mode now uses separate angle limits and applies smoother, axis-specific control.
  * Added a gradual 500 ms transition when Horizon mode is activated.
  * Configured a default Horizon angle limit of 55 degrees.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->