### PR TITLE
Alternative takeoff detection method

### DIFF
--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -1095,6 +1095,7 @@ const clivalue_t valueTable[] = {
     { "rc_threshold",               VAR_UINT8  | MASTER_VALUE | MODE_ARRAY, .config.array.length = 4, PG_RC_CONTROLS_CONFIG, offsetof(rcControlsConfig_t, rc_threshold) },
     { "airborne_mode",              VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_AIRBORNE_MODE }, PG_RC_CONTROLS_CONFIG, offsetof(rcControlsConfig_t, airborne_mode) },
     { "airborne_gyro_threshold",    VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 1, 100 }, PG_RC_CONTROLS_CONFIG, offsetof(rcControlsConfig_t, airborne_gyro_threshold) },
+    { "airborne_acc_threshold",     VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 5, 50 }, PG_RC_CONTROLS_CONFIG, offsetof(rcControlsConfig_t, airborne_acc_threshold) },
 
     { "deadband",                   VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 0, 100 }, PG_RC_CONTROLS_CONFIG, offsetof(rcControlsConfig_t, rc_deadband) },
     { "yaw_deadband",               VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 0, 100 }, PG_RC_CONTROLS_CONFIG, offsetof(rcControlsConfig_t, rc_yaw_deadband) },

--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -519,6 +519,10 @@ static const char * const lookupTableSmartFuelMode[] = {
 };
 #endif
 
+static const char * const lookupTableAirborneMode[] = {
+    "CONSERVATIVE", "STICK_RESPONSE",
+};
+
 #define LOOKUP_TABLE_ENTRY(name) { name, ARRAYLEN(name) }
 
 const lookupTableEntry_t lookupTables[] = {
@@ -636,6 +640,7 @@ const lookupTableEntry_t lookupTables[] = {
 #ifdef USE_SMARTFUEL
     LOOKUP_TABLE_ENTRY(lookupTableSmartFuelMode),
 #endif
+    LOOKUP_TABLE_ENTRY(lookupTableAirborneMode),
 };
 
 #undef LOOKUP_TABLE_ENTRY
@@ -1088,6 +1093,8 @@ const clivalue_t valueTable[] = {
     { "rc_max_throttle",            VAR_UINT16 | MASTER_VALUE, .config.minmaxUnsigned = { 0, PWM_PULSE_MAX }, PG_RC_CONTROLS_CONFIG, offsetof(rcControlsConfig_t, rc_max_throttle) },
     { "rc_smoothness",              VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 0, 250 }, PG_RC_CONTROLS_CONFIG, offsetof(rcControlsConfig_t, rc_smoothness) },
     { "rc_threshold",               VAR_UINT8  | MASTER_VALUE | MODE_ARRAY, .config.array.length = 4, PG_RC_CONTROLS_CONFIG, offsetof(rcControlsConfig_t, rc_threshold) },
+    { "airborne_mode",              VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_AIRBORNE_MODE }, PG_RC_CONTROLS_CONFIG, offsetof(rcControlsConfig_t, airborne_mode) },
+    { "airborne_gyro_threshold",    VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 1, 100 }, PG_RC_CONTROLS_CONFIG, offsetof(rcControlsConfig_t, airborne_gyro_threshold) },
 
     { "deadband",                   VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 0, 100 }, PG_RC_CONTROLS_CONFIG, offsetof(rcControlsConfig_t, rc_deadband) },
     { "yaw_deadband",               VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 0, 100 }, PG_RC_CONTROLS_CONFIG, offsetof(rcControlsConfig_t, rc_yaw_deadband) },

--- a/src/main/cli/settings.h
+++ b/src/main/cli/settings.h
@@ -135,6 +135,7 @@ typedef enum {
 #ifdef USE_SMARTFUEL
     TABLE_SMARTFUEL_MODE,
 #endif
+    TABLE_AIRBORNE_MODE,
 
     LOOKUP_TABLE_COUNT
 } lookupTableIndex_e;

--- a/src/main/fc/core.c
+++ b/src/main/fc/core.c
@@ -78,6 +78,7 @@
 #include "flight/servos.h"
 #include "flight/governor.h"
 #include "flight/rescue.h"
+#include "flight/airborne.h"
 
 #include "io/beeper.h"
 #include "io/gps.h"
@@ -676,12 +677,12 @@ void processRxModes(timeUs_t currentTimeUs)
             DISABLE_FLIGHT_MODE(RESCUE_MODE);
         }
 
-        if (IS_RC_MODE_ACTIVE(BOXANGLE)) {
+        if (IS_RC_MODE_ACTIVE(BOXANGLE) && (!ARMING_FLAG(ARMED) || isAirborne())) {
             ENABLE_FLIGHT_MODE(ANGLE_MODE);
             DISABLE_FLIGHT_MODE(HORIZON_MODE);
             DISABLE_FLIGHT_MODE(TRAINER_MODE);
         }
-        else if (IS_RC_MODE_ACTIVE(BOXHORIZON)) {
+        else if (IS_RC_MODE_ACTIVE(BOXHORIZON) && (!ARMING_FLAG(ARMED) || isAirborne())) {
             DISABLE_FLIGHT_MODE(ANGLE_MODE);
             ENABLE_FLIGHT_MODE(HORIZON_MODE);
             DISABLE_FLIGHT_MODE(TRAINER_MODE);

--- a/src/main/flight/airborne.c
+++ b/src/main/flight/airborne.c
@@ -29,6 +29,8 @@
 #include "config/config.h"
 #include "config/feature.h"
 
+#include "drivers/time.h"
+
 #include "flight/pid.h"
 #include "flight/imu.h"
 #include "flight/position.h"
@@ -37,15 +39,25 @@
 #include "fc/runtime_config.h"
 #include "fc/rc.h"
 
+#include "sensors/gyro.h"
+
 #include "airborne.h"
 
 #define FILTER_CUTOFF                       5.0f
+#define GYRO_FILTER_CUTOFF                 10.0f
 
 #define PEAK_UP_CUTOFF                     20.0f
 #define PEAK_DN_CUTOFF                      0.5f
 
 #define LIFTOFF_COS_ANGLE_THRESHOLD        0.80f
 #define LANDING_COS_ANGLE_THRESHOLD        0.90f
+
+#define LIFTOFF_MIN_TIME_MS                150
+
+typedef enum {
+    AIRBORNE_MODE_CONSERVATIVE = 0,
+    AIRBORNE_MODE_STICK_RESPONSE,
+} airborneMode_e;
 
 typedef enum {
     AIRBORNE_STATE_INIT = 0,
@@ -56,12 +68,19 @@ typedef enum {
 typedef struct
 {
     airborneState_e state;
+    airborneMode_e  mode;
 
     float liftoffThreshold[4];
     float landingThreshold[4];
+    float gyroThreshold;
 
-    pt1Filter_t filter[4];
+    pt1Filter_t  filter[4];
     peakFilter_t peakDeflection[4];
+
+    pt1Filter_t  gyroFilter[2];
+    peakFilter_t peakGyroRate[2];
+
+    timeMs_t    liftoffEntryTime;
 
 } airborneData_t;
 
@@ -71,12 +90,19 @@ static FAST_DATA_ZERO_INIT airborneData_t airborne;
 INIT_CODE void airborneInit(void)
 {
     airborne.state = AIRBORNE_STATE_LANDED;
+    airborne.mode  = rcControlsConfig()->airborne_mode;
+    airborne.gyroThreshold = rcControlsConfig()->airborne_gyro_threshold;
 
     for (int axis = 0; axis < 4; axis++) {
         pt1FilterInit(&airborne.filter[axis], FILTER_CUTOFF, pidGetPidFrequency());
         peakFilterInit(&airborne.peakDeflection[axis], PEAK_UP_CUTOFF, PEAK_DN_CUTOFF, pidGetPidFrequency());
         airborne.liftoffThreshold[axis] = rcControlsConfig()->rc_threshold[axis] / 1000.0f;
         airborne.landingThreshold[axis] = rcControlsConfig()->rc_threshold[axis] / 1500.0f;
+    }
+
+    for (int axis = 0; axis < 2; axis++) {
+        pt1FilterInit(&airborne.gyroFilter[axis], GYRO_FILTER_CUTOFF, pidGetPidFrequency());
+        peakFilterInit(&airborne.peakGyroRate[axis], PEAK_UP_CUTOFF, PEAK_DN_CUTOFF, pidGetPidFrequency());
     }
 }
 
@@ -126,20 +152,64 @@ static void updateStickDeflection(const float rc[4])
     }
 }
 
+static void updateGyroRate(void)
+{
+    for (int axis = FD_ROLL; axis <= FD_PITCH; axis++) {
+        float rate = pt1FilterApply(&airborne.gyroFilter[axis], gyro.gyroADCf[axis]);
+        peakFilterApply(&airborne.peakGyroRate[axis], fabsf(rate));
+    }
+}
+
+// STICK_RESPONSE: liftoff when the heli demonstrably follows cyclic stick input
+static bool liftoffByStickResponse(void)
+{
+    // Require stick deflection AND corresponding gyro response on the same cyclic axis
+    bool responding = false;
+    for (int axis = FD_ROLL; axis <= FD_PITCH; axis++) {
+        if (peakFilterOutput(&airborne.peakDeflection[axis]) > airborne.liftoffThreshold[axis] &&
+            peakFilterOutput(&airborne.peakGyroRate[axis])   > airborne.gyroThreshold) {
+            responding = true;
+            break;
+        }
+    }
+
+    return (
+        ARMING_FLAG(ARMED) &&
+        isSpooledUp() &&
+        (
+            responding ||
+            getCosTiltAngle() < LIFTOFF_COS_ANGLE_THRESHOLD ||
+            FLIGHT_MODE(RESCUE_MODE | GPS_RESCUE_MODE | FAILSAFE_MODE)
+        )
+    );
+}
+
 void airborneUpdate(const float rc[4])
 {
     updateStickDeflection(rc);
+    updateGyroRate();
+
+    const bool liftoffCondition = (airborne.mode == AIRBORNE_MODE_STICK_RESPONSE)
+        ? liftoffByStickResponse()
+        : liftoff();
+    const bool touchdownCondition = touchdown();
 
     switch (airborne.state) {
         case AIRBORNE_STATE_INIT:
             break;
         case AIRBORNE_STATE_LANDED:
-            if (liftoff()) {
-                airborne.state = AIRBORNE_STATE_AIRBORNE;
+            if (liftoffCondition) {
+                if (airborne.liftoffEntryTime == 0)
+                    airborne.liftoffEntryTime = millis();
+                if (cmp32(millis(), airborne.liftoffEntryTime) >= LIFTOFF_MIN_TIME_MS)
+                    airborne.state = AIRBORNE_STATE_AIRBORNE;
+            } else {
+                airborne.liftoffEntryTime = 0;
             }
             break;
         case AIRBORNE_STATE_AIRBORNE:
-            if (touchdown()) {
+            if (touchdownCondition) {
+                airborne.liftoffEntryTime = 0;
                 airborne.state = AIRBORNE_STATE_LANDED;
             }
             break;
@@ -147,11 +217,11 @@ void airborneUpdate(const float rc[4])
 
     DEBUG(AIRBORNE, 0, peakFilterOutput(&airborne.peakDeflection[FD_ROLL]) * 1000);
     DEBUG(AIRBORNE, 1, peakFilterOutput(&airborne.peakDeflection[FD_PITCH]) * 1000);
-    DEBUG(AIRBORNE, 2, peakFilterOutput(&airborne.peakDeflection[FD_YAW]) * 1000);
-    DEBUG(AIRBORNE, 3, peakFilterOutput(&airborne.peakDeflection[FD_COLL]) * 1000);
+    DEBUG(AIRBORNE, 2, peakFilterOutput(&airborne.peakGyroRate[FD_ROLL]) * 10);
+    DEBUG(AIRBORNE, 3, peakFilterOutput(&airborne.peakGyroRate[FD_PITCH]) * 10);
     DEBUG(AIRBORNE, 4, getCosTiltAngle() * 1000);
     DEBUG(AIRBORNE, 5, isSpooledUp());
-    DEBUG(AIRBORNE, 6, (liftoff() ? 1 : 0) | (touchdown() ? 2 : 0));
+    DEBUG(AIRBORNE, 6, (liftoffCondition ? 1 : 0) | (touchdownCondition ? 2 : 0));
     DEBUG(AIRBORNE, 7, airborne.state);
 }
 

--- a/src/main/flight/airborne.c
+++ b/src/main/flight/airborne.c
@@ -57,6 +57,7 @@
 #define LANDING_COS_ANGLE_THRESHOLD        0.90f
 
 #define LIFTOFF_MIN_TIME_MS                150
+#define TOUCHDOWN_MIN_AIRBORNE_MS          500
 
 typedef enum {
     AIRBORNE_MODE_CONSERVATIVE = 0,
@@ -91,6 +92,7 @@ typedef struct
 #endif
 
     timeMs_t    liftoffEntryTime;
+    timeMs_t    airborneTime;
 
 } airborneData_t;
 
@@ -240,15 +242,20 @@ void airborneUpdate(const float rc[4])
             if (liftoffCondition) {
                 if (airborne.liftoffEntryTime == 0)
                     airborne.liftoffEntryTime = millis();
-                if (cmp32(millis(), airborne.liftoffEntryTime) >= LIFTOFF_MIN_TIME_MS)
+                if (cmp32(millis(), airborne.liftoffEntryTime) >= LIFTOFF_MIN_TIME_MS) {
                     airborne.state = AIRBORNE_STATE_AIRBORNE;
+                    airborne.airborneTime = millis();
+                    pidResetAxisErrors();
+                }
             } else {
                 airborne.liftoffEntryTime = 0;
             }
             break;
         case AIRBORNE_STATE_AIRBORNE:
-            if (touchdownCondition) {
+            if (touchdownCondition &&
+                cmp32(millis(), airborne.airborneTime) >= TOUCHDOWN_MIN_AIRBORNE_MS) {
                 airborne.liftoffEntryTime = 0;
+                airborne.airborneTime = 0;
                 airborne.state = AIRBORNE_STATE_LANDED;
             }
             break;
@@ -267,6 +274,13 @@ void airborneUpdate(const float rc[4])
 bool isAirborne(void)
 {
     return (airborne.state == AIRBORNE_STATE_AIRBORNE);
+}
+
+uint32_t getLiftoffAgeMs(void)
+{
+    if (airborne.state != AIRBORNE_STATE_AIRBORNE || airborne.airborneTime == 0)
+        return 0;
+    return cmp32(millis(), airborne.airborneTime);
 }
 
 bool isHandsOn(void)

--- a/src/main/flight/airborne.c
+++ b/src/main/flight/airborne.c
@@ -40,11 +40,15 @@
 #include "fc/rc.h"
 
 #include "sensors/gyro.h"
+#ifdef USE_ACC
+#include "sensors/acceleration.h"
+#endif
 
 #include "airborne.h"
 
 #define FILTER_CUTOFF                       5.0f
 #define GYRO_FILTER_CUTOFF                 10.0f
+#define ACC_Z_CUTOFF                        5.0f
 
 #define PEAK_UP_CUTOFF                     20.0f
 #define PEAK_DN_CUTOFF                      0.5f
@@ -80,6 +84,12 @@ typedef struct
     pt1Filter_t  gyroFilter[2];
     peakFilter_t peakGyroRate[2];
 
+#ifdef USE_ACC
+    pt1Filter_t accZFilter;
+    float       accZFiltered;
+    float       accZThreshold;  // in g units, e.g. 1.15f
+#endif
+
     timeMs_t    liftoffEntryTime;
 
 } airborneData_t;
@@ -104,6 +114,12 @@ INIT_CODE void airborneInit(void)
         pt1FilterInit(&airborne.gyroFilter[axis], GYRO_FILTER_CUTOFF, pidGetPidFrequency());
         peakFilterInit(&airborne.peakGyroRate[axis], PEAK_UP_CUTOFF, PEAK_DN_CUTOFF, pidGetPidFrequency());
     }
+
+#ifdef USE_ACC
+    pt1FilterInit(&airborne.accZFilter, ACC_Z_CUTOFF, pidGetPidFrequency());
+    airborne.accZFiltered  = 1.0f;
+    airborne.accZThreshold = 1.0f + rcControlsConfig()->airborne_acc_threshold * 0.01f;
+#endif
 }
 
 static bool isOverThreshold(const float *threshold)
@@ -160,10 +176,21 @@ static void updateGyroRate(void)
     }
 }
 
-// STICK_RESPONSE: liftoff when the heli demonstrably follows cyclic stick input
+#ifdef USE_ACC
+static void updateAccZ(void)
+{
+    if (sensors(SENSOR_ACC) && acc.isAccelUpdatedAtLeastOnce) {
+        airborne.accZFiltered = pt1FilterApply(&airborne.accZFilter,
+            acc.accADC[Z] * acc.dev.acc_1G_rec);
+    }
+}
+#endif
+
+// STICK_RESPONSE: liftoff when the heli demonstrably follows cyclic stick input,
+// or when Z-axis acceleration indicates the heli has left the ground.
 static bool liftoffByStickResponse(void)
 {
-    // Require stick deflection AND corresponding gyro response on the same cyclic axis
+    // Check per-axis correlation: pilot inputs stick AND heli responds with gyro rate
     bool responding = false;
     for (int axis = FD_ROLL; axis <= FD_PITCH; axis++) {
         if (peakFilterOutput(&airborne.peakDeflection[axis]) > airborne.liftoffThreshold[axis] &&
@@ -173,11 +200,20 @@ static bool liftoffByStickResponse(void)
         }
     }
 
+#ifdef USE_ACC
+    // Hands-off liftoff: upward body-frame acceleration exceeds 1g (ground reaction gone)
+    const bool liftingOff = sensors(SENSOR_ACC) &&
+                            (airborne.accZFiltered > airborne.accZThreshold);
+#else
+    const bool liftingOff = false;
+#endif
+
     return (
         ARMING_FLAG(ARMED) &&
         isSpooledUp() &&
         (
             responding ||
+            liftingOff ||
             getCosTiltAngle() < LIFTOFF_COS_ANGLE_THRESHOLD ||
             FLIGHT_MODE(RESCUE_MODE | GPS_RESCUE_MODE | FAILSAFE_MODE)
         )
@@ -188,6 +224,9 @@ void airborneUpdate(const float rc[4])
 {
     updateStickDeflection(rc);
     updateGyroRate();
+#ifdef USE_ACC
+    updateAccZ();
+#endif
 
     const bool liftoffCondition = (airborne.mode == AIRBORNE_MODE_STICK_RESPONSE)
         ? liftoffByStickResponse()

--- a/src/main/flight/airborne.h
+++ b/src/main/flight/airborne.h
@@ -22,6 +22,7 @@
 
 bool isHandsOn(void);
 bool isAirborne(void);
+uint32_t getLiftoffAgeMs(void);
 
 void airborneInit(void);
 void airborneUpdate(const float rc[4]);

--- a/src/main/flight/leveling.c
+++ b/src/main/flight/leveling.c
@@ -44,6 +44,7 @@
 
 #include "flight/imu.h"
 #include "flight/gps_rescue.h"
+#include "flight/airborne.h"
 
 #include "sensors/acceleration.h"
 #include "sensors/gyro.h"
@@ -202,6 +203,16 @@ static float calcHorizonLevelStrength(void)
     return constrainf(horizonLevelStrength, 0, 1);
 }
 
+#define LIFTOFF_ENGAGE_RAMP_MS  300.0f
+
+static float liftoffRampFactor(void)
+{
+    const uint32_t age = getLiftoffAgeMs();
+    if (age == 0)
+        return 0.0f;
+    return constrainf((float)age / LIFTOFF_ENGAGE_RAMP_MS, 0.0f, 1.0f);
+}
+
 float angleModeApply(int axis, float pidSetpoint)
 {
     if (axis == FD_ROLL || axis == FD_PITCH)
@@ -210,6 +221,8 @@ float angleModeApply(int axis, float pidSetpoint)
 
         if (!isAirborne())
             errorAngle *= 0.25f;
+        else
+            errorAngle *= liftoffRampFactor();
 
         pidSetpoint = errorAngle * level.Gain;
     }
@@ -225,6 +238,8 @@ float horizonModeApply(int axis, float pidSetpoint)
 
         if (!isAirborne())
             errorAngle *= 0.25f;
+        else
+            errorAngle *= liftoffRampFactor();
 
         pidSetpoint += errorAngle * horizon.Gain * calcHorizonLevelStrength();
     }

--- a/src/main/pg/rx.c
+++ b/src/main/pg/rx.c
@@ -80,6 +80,7 @@ PG_RESET_TEMPLATE(rcControlsConfig_t, rcControlsConfig,
     .rc_threshold = { 25, 25, 25, 100 },
     .airborne_mode = 0,
     .airborne_gyro_threshold = 10,
+    .airborne_acc_threshold = 15,
 );
 
 extern void pgResetFn_rxFailsafeChannelConfigs(rxFailsafeChannelConfig_t *rxFailsafeChannelConfigs);

--- a/src/main/pg/rx.c
+++ b/src/main/pg/rx.c
@@ -78,6 +78,8 @@ PG_RESET_TEMPLATE(rcControlsConfig_t, rcControlsConfig,
     .rc_yaw_deadband = 5,
     .rc_smoothness = 50,
     .rc_threshold = { 25, 25, 25, 100 },
+    .airborne_mode = 0,
+    .airborne_gyro_threshold = 10,
 );
 
 extern void pgResetFn_rxFailsafeChannelConfigs(rxFailsafeChannelConfig_t *rxFailsafeChannelConfigs);

--- a/src/main/pg/rx.h
+++ b/src/main/pg/rx.h
@@ -64,6 +64,7 @@ typedef struct rcControlsConfig_s {
     uint8_t  rc_threshold[4];           // Threshold for stick activity
     uint8_t  airborne_mode;             // 0=CONSERVATIVE (timer debounce), 1=STICK_RESPONSE (requires gyro response)
     uint8_t  airborne_gyro_threshold;   // Gyro rate threshold for STICK_RESPONSE mode (deg/s)
+    uint8_t  airborne_acc_threshold;    // Z-acc liftoff threshold offset for STICK_RESPONSE mode (× 0.01 g, e.g. 15 → 1.15 g)
 } rcControlsConfig_t;
 
 PG_DECLARE(rcControlsConfig_t, rcControlsConfig);

--- a/src/main/pg/rx.h
+++ b/src/main/pg/rx.h
@@ -62,6 +62,8 @@ typedef struct rcControlsConfig_s {
     uint8_t  rc_yaw_deadband;           // A deadband around the stick center for yaw axis
     uint8_t  rc_smoothness;             // Minimum RPYC smoothing level
     uint8_t  rc_threshold[4];           // Threshold for stick activity
+    uint8_t  airborne_mode;             // 0=CONSERVATIVE (timer debounce), 1=STICK_RESPONSE (requires gyro response)
+    uint8_t  airborne_gyro_threshold;   // Gyro rate threshold for STICK_RESPONSE mode (deg/s)
 } rcControlsConfig_t;
 
 PG_DECLARE(rcControlsConfig_t, rcControlsConfig);


### PR DESCRIPTION
For small helis like the S2 and especially heavier scale helis the takeoff detection did not work too reliably and the helis had a tendency to tip over. This also adds the ability to take off in a stabilized mode, which makes flying in narrow spaces and indoors much easier.

### New `STICK_RESPONSE` airborne detection mode
The existing `CONSERVATIVE` mode detects liftoff purely from stick deflection.
The new `STICK_RESPONSE` mode additionally requires the helicopter to *respond*
to cyclic input with measurable gyro rates, confirming it has left the ground:

- Gyro rate on roll/pitch axes is low-pass filtered and peak-tracked, then
  compared against a configurable threshold (`airborne_gyro_threshold`).
- A liftoff is also triggered when Z-axis accelerometer reading exceeds a
  configurable threshold (`airborne_acc_threshold`), detecting the disappearance
  of ground reaction force even with hands off the sticks.
- Failsafe, rescue, and extreme tilt angle still trigger liftoff as before.

### Debounce timing
- Liftoff requires the liftoff condition to hold for **150 ms** before the state
  transitions to AIRBORNE, filtering out brief ground hops.
- Touchdown is ignored for the first **500 ms** of flight, preventing an
  immediate re-land detection.

### Angle / Horizon mode activation gating (`core.c`)
ANGLE_MODE and HORIZON_MODE are now only enabled while the helicopter is airborne
(or disarmed). This prevents the leveling controller from fighting the pilot
during ground handling, taxiing, and spoolup.

### Liftoff ramp for leveling (`leveling.c`)
Both `angleModeApply()` and `horizonModeApply()` now scale the leveling
correction by a **300 ms linear ramp** after liftoff (`getLiftoffAgeMs()`).
This eliminates the sudden jolt in pitch/roll correction at the moment of takeoff.

### New airborne-time tracking
`getLiftoffAgeMs()` returns how many milliseconds the helicopter has been
continuously airborne. Currently used by the liftoff ramp; can be reused by
other subsystems in the future.

### Debug output update
Airborne debug channels 2 and 3 now show peak gyro rates (roll/pitch) instead
of yaw/collective stick deflection, which is more useful for tuning the new
`STICK_RESPONSE` mode.

## New CLI settings

| Setting | Range | Default | Description |
|---|---|---|---|
| `airborne_mode` | `CONSERVATIVE` / `STICK_RESPONSE` | `CONSERVATIVE` | Liftoff detection algorithm |
| `airborne_gyro_threshold` | 1–100 °/s | 10 | Minimum gyro response to confirm liftoff |
| `airborne_acc_threshold` | 5–50 (× 0.01 g) | 15 → 1.15 g | Z-axis acceleration threshold for hands-off liftoff detection |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable airborne detection modes with gyro and accelerometer thresholds.
  - Improved liftoff and touchdown detection using sustained motion and timing safeguards.
  - Added a liftoff engagement ramp for smoother Angle and Horizon mode behavior.
  - Angle and Horizon modes now activate only when the craft is safely airborne or disarmed.
  - Added CLI settings for selecting airborne mode and adjusting detection thresholds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->