### PR TITLE
Fix forwarding of sport master sensors

### DIFF
--- a/src/main/telemetry/sensors.c
+++ b/src/main/telemetry/sensors.c
@@ -64,6 +64,11 @@
 #include "pg/fbus_master.h"
 #endif
 
+#ifdef USE_SPORT_MASTER
+#include "sport_master.h"
+#endif
+
+
 /** Sensor functions **/
 
 static int getVoltage(voltageMeterId_e id)
@@ -566,21 +571,29 @@ bool telemetrySensorActive(sensor_id_e id)
 
 #ifdef USE_FBUS_MASTER
         case TELEM_FBUS_SENSOR_1:
-            return fbusMasterIsEnabled() && (fbusMasterConfig()->forwardedSensors[0] <= FBUS_MAX_PHYS_ID);
+            return (fbusMasterIsEnabled() || sportMasterIsEnabled())
+                        && (fbusMasterConfig()->forwardedSensors[0] <= FBUS_MAX_PHYS_ID);
         case TELEM_FBUS_SENSOR_2:
-            return fbusMasterIsEnabled() && (fbusMasterConfig()->forwardedSensors[1] <= FBUS_MAX_PHYS_ID);
+            return (fbusMasterIsEnabled() || sportMasterIsEnabled())
+                        && (fbusMasterConfig()->forwardedSensors[1] <= FBUS_MAX_PHYS_ID);
         case TELEM_FBUS_SENSOR_3:
-            return fbusMasterIsEnabled() && (fbusMasterConfig()->forwardedSensors[2] <= FBUS_MAX_PHYS_ID);
+            return (fbusMasterIsEnabled() || sportMasterIsEnabled())
+                        && (fbusMasterConfig()->forwardedSensors[2] <= FBUS_MAX_PHYS_ID);
         case TELEM_FBUS_SENSOR_4:
-            return fbusMasterIsEnabled() && (fbusMasterConfig()->forwardedSensors[3] <= FBUS_MAX_PHYS_ID);
+            return (fbusMasterIsEnabled() || sportMasterIsEnabled())
+                        && (fbusMasterConfig()->forwardedSensors[3] <= FBUS_MAX_PHYS_ID);
         case TELEM_FBUS_SENSOR_5:
-            return fbusMasterIsEnabled() && (fbusMasterConfig()->forwardedSensors[4] <= FBUS_MAX_PHYS_ID);
+            return (fbusMasterIsEnabled() || sportMasterIsEnabled())
+                        && (fbusMasterConfig()->forwardedSensors[4] <= FBUS_MAX_PHYS_ID);
         case TELEM_FBUS_SENSOR_6:
-            return fbusMasterIsEnabled() && (fbusMasterConfig()->forwardedSensors[5] <= FBUS_MAX_PHYS_ID);
+            return (fbusMasterIsEnabled() || sportMasterIsEnabled())
+                        && (fbusMasterConfig()->forwardedSensors[5] <= FBUS_MAX_PHYS_ID);
         case TELEM_FBUS_SENSOR_7:
-            return fbusMasterIsEnabled() && (fbusMasterConfig()->forwardedSensors[6] <= FBUS_MAX_PHYS_ID);
+            return (fbusMasterIsEnabled() || sportMasterIsEnabled())
+                        && (fbusMasterConfig()->forwardedSensors[6] <= FBUS_MAX_PHYS_ID);
         case TELEM_FBUS_SENSOR_8:
-            return fbusMasterIsEnabled() && (fbusMasterConfig()->forwardedSensors[7] <= FBUS_MAX_PHYS_ID);
+            return (fbusMasterIsEnabled() || sportMasterIsEnabled())
+                        && (fbusMasterConfig()->forwardedSensors[7] <= FBUS_MAX_PHYS_ID);
 #endif
 
         default:

--- a/src/main/telemetry/sensors.c
+++ b/src/main/telemetry/sensors.c
@@ -59,15 +59,17 @@
 #include "telemetry/sensors.h"
 
 #ifdef USE_FBUS_MASTER
-#include "drivers/fbus_sensor.h"
-#include "drivers/fbus_master.h"
-#include "pg/fbus_master.h"
+# include "drivers/fbus_sensor.h"
+# include "drivers/fbus_master.h"
+# include "pg/fbus_master.h"
+// Note: forwarding SPORT_MASTER sensors requires FBUS_MASTER to be enabled
+# ifdef USE_SPORT_MASTER
+#  include "sport_master.h"
+#  define CHECK_FBUS_SPORT_MASTER_ENABLED() (fbusMasterIsEnabled() || sportMasterIsEnabled())
+# else
+#  define CHECK_FBUS_SPORT_MASTER_ENABLED() fbusMasterIsEnabled()
+# endif
 #endif
-
-#ifdef USE_SPORT_MASTER
-#include "sport_master.h"
-#endif
-
 
 /** Sensor functions **/
 
@@ -571,29 +573,21 @@ bool telemetrySensorActive(sensor_id_e id)
 
 #ifdef USE_FBUS_MASTER
         case TELEM_FBUS_SENSOR_1:
-            return (fbusMasterIsEnabled() || sportMasterIsEnabled())
-                        && (fbusMasterConfig()->forwardedSensors[0] <= FBUS_MAX_PHYS_ID);
+            return CHECK_FBUS_SPORT_MASTER_ENABLED() && (fbusMasterConfig()->forwardedSensors[0] <= FBUS_MAX_PHYS_ID);
         case TELEM_FBUS_SENSOR_2:
-            return (fbusMasterIsEnabled() || sportMasterIsEnabled())
-                        && (fbusMasterConfig()->forwardedSensors[1] <= FBUS_MAX_PHYS_ID);
+            return CHECK_FBUS_SPORT_MASTER_ENABLED() && (fbusMasterConfig()->forwardedSensors[1] <= FBUS_MAX_PHYS_ID);
         case TELEM_FBUS_SENSOR_3:
-            return (fbusMasterIsEnabled() || sportMasterIsEnabled())
-                        && (fbusMasterConfig()->forwardedSensors[2] <= FBUS_MAX_PHYS_ID);
+            return CHECK_FBUS_SPORT_MASTER_ENABLED() && (fbusMasterConfig()->forwardedSensors[2] <= FBUS_MAX_PHYS_ID);
         case TELEM_FBUS_SENSOR_4:
-            return (fbusMasterIsEnabled() || sportMasterIsEnabled())
-                        && (fbusMasterConfig()->forwardedSensors[3] <= FBUS_MAX_PHYS_ID);
+            return CHECK_FBUS_SPORT_MASTER_ENABLED() && (fbusMasterConfig()->forwardedSensors[3] <= FBUS_MAX_PHYS_ID);
         case TELEM_FBUS_SENSOR_5:
-            return (fbusMasterIsEnabled() || sportMasterIsEnabled())
-                        && (fbusMasterConfig()->forwardedSensors[4] <= FBUS_MAX_PHYS_ID);
+            return CHECK_FBUS_SPORT_MASTER_ENABLED() && (fbusMasterConfig()->forwardedSensors[4] <= FBUS_MAX_PHYS_ID);
         case TELEM_FBUS_SENSOR_6:
-            return (fbusMasterIsEnabled() || sportMasterIsEnabled())
-                        && (fbusMasterConfig()->forwardedSensors[5] <= FBUS_MAX_PHYS_ID);
+            return CHECK_FBUS_SPORT_MASTER_ENABLED() && (fbusMasterConfig()->forwardedSensors[5] <= FBUS_MAX_PHYS_ID);
         case TELEM_FBUS_SENSOR_7:
-            return (fbusMasterIsEnabled() || sportMasterIsEnabled())
-                        && (fbusMasterConfig()->forwardedSensors[6] <= FBUS_MAX_PHYS_ID);
+            return CHECK_FBUS_SPORT_MASTER_ENABLED() && (fbusMasterConfig()->forwardedSensors[6] <= FBUS_MAX_PHYS_ID);
         case TELEM_FBUS_SENSOR_8:
-            return (fbusMasterIsEnabled() || sportMasterIsEnabled())
-                        && (fbusMasterConfig()->forwardedSensors[7] <= FBUS_MAX_PHYS_ID);
+            return CHECK_FBUS_SPORT_MASTER_ENABLED() && (fbusMasterConfig()->forwardedSensors[7] <= FBUS_MAX_PHYS_ID);
 #endif
 
         default:


### PR DESCRIPTION
Fix an issue where sport sensors connected to the sport master are not forwarded on to the receiver via FBUS. This was observed on the Vantac RF007 with a single FLVSS (LiPo) sensor connected.

The fix was tested in several flights.

closes #477 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Forwarded telemetry sensors now activate correctly when the S.Port master feature is enabled.
  * Existing validation for configured forwarded sensor identifiers remains in place.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->