### PR TITLE
Add MSP commands for FBUS/S.Port sensor diagnostics and forwarding

### DIFF
--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -42,6 +42,7 @@
 #include "common/color.h"
 #include "common/huffman.h"
 #include "common/maths.h"
+#include "common/printf.h"
 #include "common/streambuf.h"
 #include "common/utils.h"
 
@@ -57,6 +58,7 @@
 #include "drivers/display.h"
 #include "drivers/dshot.h"
 #include "drivers/dshot_command.h"
+#include "drivers/fbus_sensor.h"
 #include "drivers/flash.h"
 #include "drivers/io.h"
 #include "drivers/motor.h"
@@ -1363,6 +1365,51 @@ static bool mspProcessOutCommand(int16_t cmdMSP, sbuf_t *dst)
         sbufWriteU8(dst, batteryConfig()->smartfuel_charge_drop_rate);
         sbufWriteU8(dst, batteryConfig()->smartfuel_sag_gain);
         break;
+#endif
+
+#if defined(USE_FBUS_MASTER) || defined(USE_SPORT_MASTER)
+    case MSP2_GET_FBUS_SENSORS: {
+        const uint8_t count = fbusSensorGetObservedCount();
+        sbufWriteU8(dst, count);
+
+        for (uint8_t i = 0; i < count; i++) {
+            const fbusObservedSensor_t *sensor = fbusSensorGetObserved(i);
+            if (!sensor) {
+                break;
+            }
+
+            sbufWriteU8(dst, sensor->physicalId);
+            sbufWriteU8(dst, sensor->source);
+            sbufWriteU8(dst, fbusSensorIsForwarded(sensor->physicalId) ? 1 : 0);
+            sbufWriteU32(dst, sensor->packetCount);
+
+            // Mirror the CLI's "ID_XXX" fallback for unnamed physical IDs so
+            // both surfaces show identical sensor names.
+            const char *sensorName = fbusSensorGetName(sensor->physicalId);
+            char nameBuffer[17];
+            if (strcmp(sensorName, "UNKNOWN") == 0) {
+                tfp_sprintf(nameBuffer, "ID_%u", sensor->physicalId);
+                sensorName = nameBuffer;
+            }
+            const uint8_t nameLen = (uint8_t)strlen(sensorName);
+            sbufWriteU8(dst, nameLen);
+            sbufWriteData(dst, sensorName, nameLen);
+
+            sbufWriteU8(dst, sensor->appIdCount);
+            for (uint8_t j = 0; j < sensor->appIdCount; j++) {
+                sbufWriteU16(dst, sensor->appIds[j]);
+            }
+        }
+        break;
+    }
+
+    case MSP2_GET_FBUS_MASTER_CONFIG: {
+        sbufWriteU8(dst, 1); // payload version -- only the forwarding slots so far
+        for (int i = 0; i < FBUS_MASTER_MAX_FORWARDED_SENSORS; i++) {
+            sbufWriteU8(dst, fbusMasterConfig()->forwardedSensors[i]);
+        }
+        break;
+    }
 #endif
 
     case MSP_RC:
@@ -3903,6 +3950,21 @@ static mspResult_e mspCommonProcessInCommand(mspDescriptor_t srcDesc, int16_t cm
         batteryConfigMutable()->smartfuel_charge_drop_rate = sbufReadU8(src);
         batteryConfigMutable()->smartfuel_sag_gain = sbufReadU8(src);
         smartFuelInit();
+        break;
+#endif
+
+#if defined(USE_FBUS_MASTER) || defined(USE_SPORT_MASTER)
+    case MSP2_CLEAR_FBUS_SENSORS:
+        fbusSensorClearObserved();
+        break;
+
+    case MSP2_SET_FBUS_MASTER_CONFIG:
+        for (int i = 0; i < FBUS_MASTER_MAX_FORWARDED_SENSORS; i++) {
+            fbusMasterConfigMutable()->forwardedSensors[i] = sbufReadU8(src);
+        }
+        // Forwarding buffers are only loaded from config at boot -- reload
+        // them now so the change is live immediately, without a reboot.
+        fbusSensorInitForwarding();
         break;
 #endif
 

--- a/src/main/msp/msp_protocol_v2_rotorflight.h
+++ b/src/main/msp/msp_protocol_v2_rotorflight.h
@@ -18,3 +18,8 @@
 #define MSP2_GET_SMARTFUEL_CONFIG           0x4000
 #define MSP2_SET_SMARTFUEL_CONFIG           0x4001
 
+#define MSP2_GET_FBUS_SENSORS               0x5F07
+#define MSP2_CLEAR_FBUS_SENSORS             0x5F08
+#define MSP2_GET_FBUS_MASTER_CONFIG         0x5F09
+#define MSP2_SET_FBUS_MASTER_CONFIG         0x5F0A
+


### PR DESCRIPTION
## Summary

Exposes the CLI's `fbus_sensors` command and the FBUS master's sensor forwarding config over MSP, so the Configurator can build a live diagnostic/control page instead of requiring the CLI.

New commands in `msp_protocol_v2_rotorflight.h` (IDs `0x5F07`-`0x5F0A`), all gated on `USE_FBUS_MASTER || USE_SPORT_MASTER`:

- `MSP2_GET_FBUS_SENSORS` -- mirrors `cliFbusSensors`'s output: observed sensors with physical ID, source, forwarded status, name, packet count, and app IDs.
- `MSP2_CLEAR_FBUS_SENSORS` -- clears the observed-sensor table (mirrors `fbus_sensors clear`).
- `MSP2_GET_FBUS_MASTER_CONFIG` / `MSP2_SET_FBUS_MASTER_CONFIG` -- get/set the 8-slot `forwardedSensors` array, previously only reachable via `set fbus_master_forwarded_sensors`. The set handler also calls `fbusSensorInitForwarding()` to reload the forwarding buffers immediately, since they were previously only loaded from config at boot -- without this, a config write wouldn't take effect until reboot.

Companion Configurator PR (adds the UI that uses these commands): rotorflight/rotorflight-configurator#427

## Testing

Built cleanly for MATEKF405 (`USE_FBUS_MASTER`/`USE_SPORT_MASTER` enabled there), no warnings.
