### PR TITLE
Support Spektrum full size receivers such as the AR6610T

### DIFF
--- a/src/main/fc/init.c
+++ b/src/main/fc/init.c
@@ -157,6 +157,7 @@
 
 #include "rx/rx.h"
 #include "rx/spektrum.h"
+#include "rx/srxl2.h"
 
 #include "scheduler/scheduler.h"
 
@@ -538,6 +539,10 @@ void init(void)
 
 #ifdef USE_SERIAL_PRINTF
     printfSerialInit(PRINTF_SERIAL_PORT, PRINTF_SERIAL_SPEED, PRINTF_SERIAL_OPTIONS);
+#endif
+
+#ifdef USE_SERIALRX_SRXL2
+    srxl2InitSmartThrottle(rxConfig());
 #endif
 
     mixerInit();

--- a/src/main/fc/init.c
+++ b/src/main/fc/init.c
@@ -542,7 +542,7 @@ void init(void)
 #endif
 
 #ifdef USE_SERIALRX_SRXL2
-    srxl2InitSmartThrottle(rxConfig());
+    srxl2RxEarlyInit(rxConfig());
 #endif
 
     mixerInit();

--- a/src/main/rx/srxl2.c
+++ b/src/main/rx/srxl2.c
@@ -287,10 +287,12 @@ bool srxl2IsPacketValid(void)
 // @note assumes packet is fully there
 void srxl2Process(rxRuntimeState_t *rxRuntimeState)
 {
-    if (srxl2IsPacketValid()) {
-        //Packet is valid only after ID and CRC check out
-        lastValidPacketTimestamp = micros();
+    if (!srxl2IsPacketValid()) {
+        return;
     }
+
+    //Packet is valid only after ID and CRC check out
+    lastValidPacketTimestamp = micros();
 
     if (srxl2ProcessPacket(&processBufferPtr->packet.header, rxRuntimeState)) {
         return;

--- a/src/main/rx/srxl2.c
+++ b/src/main/rx/srxl2.c
@@ -535,11 +535,11 @@ static void srxl2InitSerialPort(const rxConfig_t *rxConfig)
         serialPort->idleCallback = srxl2Idle;
 }
 
-void srxl2InitSmartThrottle(const rxConfig_t *rxConfig)
+void srxl2RxEarlyInit(const rxConfig_t *rxConfig)
 {
-    // Get smart throttle devices to switch to SRXL2 mode, which must be done very shortly (<<
-    // 200ms) after receiver power-on.  This is only done if our own unit ID is 0 (as specified
-    // in the SRXL2 protocol)
+    // Get full size receivers to switch to SRXL2 mode. This must be done very shortly (less than
+    // 200ms) after receiver power-on, or the receiver port (typically port "1") will revert to
+    // PWM.  This is only done if our own unit ID is 0 (as specified in the SRXL2 protocol)
     //
     // This does not implement the entire handshake algorithm, because that could take a long
     // time and delay initialization -- e.g. the AR6610T polls 10 devices, taking about 30ms
@@ -562,7 +562,7 @@ void srxl2InitSmartThrottle(const rxConfig_t *rxConfig)
     if (!serialPort) {
         return;
     }
-    DEBUG_PRINTF("Running SRXL2 Smart Throttle init\r\n");
+    DEBUG_PRINTF("Running srxl2RxEarlyInit\r\n");
     uint32_t start_micros = micros();
     uint32_t now = start_micros;
     while ((now - start_micros) < 50000) {
@@ -581,7 +581,7 @@ void srxl2InitSmartThrottle(const rxConfig_t *rxConfig)
         // transmit, and since we don't count the associated idle, prevent a subsequent
         // transmission.
         lastReceiveTimestamp = 0;
-        DEBUG_PRINTF("SmartStart: Sending handshake to 0 (%d)\r\n", i);
+        DEBUG_PRINTF("srlx2RxEarlyInit: Sending handshake to 0 (%d)\r\n", i);
         srxl2SendHandshake(SRXL2_DEVICE_ID_NONE);
         start_micros = now;
         while ((now - start_micros) < 50000) {
@@ -594,14 +594,14 @@ void srxl2InitSmartThrottle(const rxConfig_t *rxConfig)
                 processBufferPtr->len = 0;
                 if (packetIsValid) {
                     // We don't process this packet because we're not fully initialized.
-                    DEBUG_PRINTF("Exiting smart throttle init successfully\r\n");
+                    DEBUG_PRINTF("Exiting srxl2RxEarlyInit successfully\r\n");
                     return;
                 }
             }
             now = micros();
         }
     }
-    DEBUG_PRINTF("Exiting smart throttle init without seeing activity\r\n");
+    DEBUG_PRINTF("Exiting srxl2RxEarlyInit init without seeing activity\r\n");
 }
 
 bool srxl2RxInit(const rxConfig_t *rxConfig, rxRuntimeState_t *rxRuntimeState)
@@ -623,7 +623,7 @@ bool srxl2RxInit(const rxConfig_t *rxConfig, rxRuntimeState_t *rxRuntimeState)
     rxRuntimeState->rcFrameTimeUsFn = rxFrameTimeUs;
     rxRuntimeState->rcProcessFrameFn = srxl2ProcessFrame;
 
-    // Serial port may have been initialized in srxl2InitSmartThrottle()
+    // Serial port may have been initialized in srxl2EarlyInit()
     if (!serialPort) {
         srxl2InitSerialPort(rxConfig);
     }

--- a/src/main/rx/srxl2.c
+++ b/src/main/rx/srxl2.c
@@ -66,8 +66,10 @@
 #define SRXL2_REPLY_QUIESCENCE         (2 * 10 * 1000000 / SRXL2_PORT_BAUDRATE_DEFAULT) // 2 * (lastIdleTimestamp - lastReceiveTimestamp). Time taken to send 2 bytes
 
 #define SRXL2_ID                       0xA6
+#define SRXL2_U_ID_2                   0x00000000
 #define SRXL2_MAX_PACKET_LENGTH        80
 #define SRXL2_DEVICE_ID_BROADCAST      0xFF
+#define SRXL2_DEVICE_ID_NONE           0
 
 #define SRXL2_FRAME_TIMEOUT_US         50000
 
@@ -114,6 +116,27 @@ static uint8_t telemetryFrame[22];
 
 uint8_t globalResult = 0;
 
+static void srxl2SendHandshake(uint8_t destDeviceId)
+{
+    Srxl2HandshakeFrame response = {
+        .header = {
+            .id = SRXL2_ID,
+            .packetType = Handshake,
+            .length = sizeof(Srxl2HandshakeFrame),
+        },
+        .payload = {
+            .sourceDeviceId = ((FlightController << 4) | unitId),
+            .destinationDeviceId = destDeviceId,
+            .priority = 10,
+            .baudSupported = baudRate,
+            .info = 0,
+            .uniqueId = SRXL2_U_ID_2, /* this isn't very unique */
+        }
+    };
+
+    srxl2RxWriteData(&response, sizeof(response));
+}
+
 /* handshake protocol
     1. listen for 50ms for serial activity and go to State::Running if found, autobaud may be necessary
     2. if srxl2_unitId = 0:
@@ -150,19 +173,7 @@ bool srxl2ProcessHandshake(const Srxl2Header* header)
 
     DEBUG_PRINTF("FC handshake from %x\r\n", handshake->sourceDeviceId);
 
-    Srxl2HandshakeFrame response = {
-        .header = *header,
-        .payload = {
-            handshake->destinationDeviceId,
-            handshake->sourceDeviceId,
-            /* priority */ 10,
-            /* baudSupported*/ baudRate,
-            /* info */ 0,
-            // U_ID_2
-        }
-    };
-
-    srxl2RxWriteData(&response, sizeof(response));
+    srxl2SendHandshake(handshake->sourceDeviceId);
 
     return true;
 }
@@ -254,13 +265,12 @@ bool srxl2ProcessPacket(const Srxl2Header* header, rxRuntimeState_t *rxRuntimeSt
     return false;
 }
 
-// @note assumes packet is fully there
-void srxl2Process(rxRuntimeState_t *rxRuntimeState)
+bool srxl2IsPacketValid(void)
 {
     if (processBufferPtr->packet.header.id != SRXL2_ID || processBufferPtr->len != processBufferPtr->packet.header.length) {
         DEBUG_PRINTF("invalid header id: %x, or length: %x received vs %x expected \r\n", processBufferPtr->packet.header.id, processBufferPtr->len, processBufferPtr->packet.header.length);
         globalResult = RX_FRAME_DROPPED;
-        return;
+        return false;
     }
 
     const uint16_t calculatedCrc = crc16_ccitt_update(0, processBufferPtr->packet.raw, processBufferPtr->packet.header.length);
@@ -269,11 +279,18 @@ void srxl2Process(rxRuntimeState_t *rxRuntimeState)
     if (calculatedCrc) {
         globalResult = RX_FRAME_DROPPED;
         DEBUG_PRINTF("crc mismatch %x\r\n", calculatedCrc);
-        return;
+        return false;
     }
+    return true;
+}
 
-    //Packet is valid only after ID and CRC check out
-    lastValidPacketTimestamp = micros();
+// @note assumes packet is fully there
+void srxl2Process(rxRuntimeState_t *rxRuntimeState)
+{
+    if (srxl2IsPacketValid()) {
+        //Packet is valid only after ID and CRC check out
+        lastValidPacketTimestamp = micros();
+    }
 
     if (srxl2ProcessPacket(&processBufferPtr->packet.header, rxRuntimeState)) {
         return;
@@ -352,6 +369,7 @@ static uint8_t srxl2FrameStatus(rxRuntimeState_t *rxRuntimeState)
             // if there were - go to either Send Handshake or Listen For Handshake
             state = Running;
         } else if (cmpTimeUs(lastIdleTimestamp, lastReceiveTimestamp) > 0) {
+            // This means we received something invalid.
             if (baudRate != 0) {
                 uint32_t currentBaud = serialGetBaudRate(serialPort);
 
@@ -359,6 +377,7 @@ static uint8_t srxl2FrameStatus(rxRuntimeState_t *rxRuntimeState)
                     serialSetBaudRate(serialPort, SRXL2_PORT_BAUDRATE_HIGH);
                 else
                     serialSetBaudRate(serialPort, SRXL2_PORT_BAUDRATE_DEFAULT);
+                lastIdleTimestamp = 0;
             }
         } else if (cmpTimeUs(now, timeoutTimestamp) >= 0) {
             // @todo if there was activity - detect baudrate and ListenForHandshake
@@ -367,6 +386,11 @@ static uint8_t srxl2FrameStatus(rxRuntimeState_t *rxRuntimeState)
                 state = SendHandshake;
                 timeoutTimestamp = now + SRXL2_SEND_HANDSHAKE_TIMEOUT_US;
                 fullTimeoutTimestamp = now + SRXL2_LISTEN_FOR_HANDSHAKE_TIMEOUT_US;
+                lastIdleTimestamp = lastReceiveTimestamp + 1; // Allow transmission
+                DEBUG_PRINTF("Sending first handshake to 0\r\n");
+                serialSetBaudRate(serialPort, SRXL2_PORT_BAUDRATE_DEFAULT);
+                srxl2SendHandshake(SRXL2_DEVICE_ID_NONE);
+                result |= RX_FRAME_PROCESSING_REQUIRED;
             } else {
                 state = ListenForHandshake;
                 timeoutTimestamp = now + SRXL2_LISTEN_FOR_HANDSHAKE_TIMEOUT_US;
@@ -375,13 +399,9 @@ static uint8_t srxl2FrameStatus(rxRuntimeState_t *rxRuntimeState)
     } break;
 
     case SendHandshake: {
-        if (cmpTimeUs(now, timeoutTimestamp) >= 0) {
-            // @todo set another timeout for 50ms tries
-            // fill write buffer with handshake frame
-            result |= RX_FRAME_PROCESSING_REQUIRED;
-        }
-
-        if (cmpTimeUs(now, fullTimeoutTimestamp) >= 0) {
+        if (lastValidPacketTimestamp != 0) {
+            state = Running;
+        } else if (cmpTimeUs(now, fullTimeoutTimestamp) >= 0) {
             serialSetBaudRate(serialPort, SRXL2_PORT_BAUDRATE_DEFAULT);
             DEBUG_PRINTF("case SendHandshake: switching to %d baud\r\n", SRXL2_PORT_BAUDRATE_DEFAULT);
             timeoutTimestamp = now + SRXL2_LISTEN_FOR_ACTIVITY_TIMEOUT_US;
@@ -389,7 +409,14 @@ static uint8_t srxl2FrameStatus(rxRuntimeState_t *rxRuntimeState)
 
             state = ListenForActivity;
             lastReceiveTimestamp = 0;
+        } else if (cmpTimeUs(now, timeoutTimestamp) >= 0) {
+            timeoutTimestamp = now + SRXL2_SEND_HANDSHAKE_TIMEOUT_US;
+            lastIdleTimestamp = lastReceiveTimestamp + 1; // Allow transmission
+            DEBUG_PRINTF("Sending handshake to 0\r\n");
+            srxl2SendHandshake(SRXL2_DEVICE_ID_NONE);
+            result |= RX_FRAME_PROCESSING_REQUIRED;
         }
+
     } break;
 
     case ListenForHandshake: {
@@ -482,6 +509,99 @@ void validateAndFixSrxl2Config(void)
     rxConfigMutable()->halfDuplex = true;
 }
 
+static void srxl2InitSerialPort(const rxConfig_t *rxConfig)
+{
+    const serialPortConfig_t *portConfig = findSerialPortConfig(FUNCTION_RX_SERIAL);
+    if (!portConfig) {
+        serialPort = NULL;
+        return;
+    }
+
+    serialPort = openSerialPort(
+                     portConfig->identifier,
+                     FUNCTION_RX_SERIAL,
+                     srxl2DataReceive,
+                     NULL,
+                     SRXL2_PORT_BAUDRATE_DEFAULT,
+                     SRXL2_PORT_MODE,
+                     SRXL2_PORT_OPTIONS |
+                     (rxConfig->serialrx_inverted ? SERIAL_INVERTED : SERIAL_NOT_INVERTED) |
+                     (rxConfig->halfDuplex ? SERIAL_BIDIR : SERIAL_UNIDIR) |
+                     (rxConfig->pinSwap ? SERIAL_PINSWAP : SERIAL_NOSWAP)
+                 );
+    if (serialPort)
+        serialPort->idleCallback = srxl2Idle;
+}
+
+void srxl2InitSmartThrottle(const rxConfig_t *rxConfig)
+{
+    // Get smart throttle devices to switch to SRXL2 mode, which must be done very shortly (<<
+    // 200ms) after receiver power-on.  This is only done if our own unit ID is 0 (as specified
+    // in the SRXL2 protocol)
+    //
+    // This does not implement the entire handshake algorithm, because that could take a long
+    // time and delay initialization -- e.g. the AR6610T polls 10 devices, taking about 30ms
+    // each.
+    //
+    // Instead, it implements only the first 2 steps of the algorithm.
+    //
+    // 1) Wait 50ms for activity on the line.  If there is any, just exit and do the full
+    // handshake at startup.  Don't validate packets since we may be at the wrong baud rate.
+    //
+    // 2) Send up to three handshake packets to device 0, 50ms apart.  If we see a valid packet
+    //    on the bus at any point, exit.
+    //
+    // When full initialization occurs, we will re-sync as if communication was lost.
+    unitId = rxConfig->srxl2_unit_id;
+    baudRate = rxConfig->srxl2_baud_fast;
+    if (unitId != 0 || rxConfig->serialrx_provider != SERIALRX_SRXL2)
+        return;
+    srxl2InitSerialPort(rxConfig);
+    if (!serialPort) {
+        return;
+    }
+    DEBUG_PRINTF("Running SRXL2 Smart Throttle init\r\n");
+    uint32_t start_micros = micros();
+    uint32_t now = start_micros;
+    while ((now - start_micros) < 50000) {
+        if (lastReceiveTimestamp > 0) {
+            // Any activity on the bus is sufficient to skip sending the initial handshake
+            // packets.
+            DEBUG_PRINTF("Received something, allow regular algo to take it\r\n");
+            return;
+        }
+        now = micros();
+    }
+
+    ++lastIdleTimestamp; // ProcessFrame won't send data if lastIdleTimestamp = lastReceiveTimestamp
+    for (int i = 0; i < 3; i++) {
+        // Since we receive our own data, lastReceiveTimestamp will be set forward whenever we
+        // transmit, and since we don't count the associated idle, prevent a subsequent
+        // transmission.
+        lastReceiveTimestamp = 0;
+        DEBUG_PRINTF("SmartStart: Sending handshake to 0 (%d)\r\n", i);
+        srxl2SendHandshake(SRXL2_DEVICE_ID_NONE);
+        start_micros = now;
+        while ((now - start_micros) < 50000) {
+            if (writeBufferIdx) {
+                // This writes the handshake packet.
+                srxl2ProcessFrame(NULL);
+            }
+            if (processBufferPtr != NULL && processBufferPtr->len) {
+                bool packetIsValid = srxl2IsPacketValid();
+                processBufferPtr->len = 0;
+                if (packetIsValid) {
+                    // We don't process this packet because we're not fully initialized.
+                    DEBUG_PRINTF("Exiting smart throttle init successfully\r\n");
+                    return;
+                }
+            }
+            now = micros();
+        }
+    }
+    DEBUG_PRINTF("Exiting smart throttle init without seeing activity\r\n");
+}
+
 bool srxl2RxInit(const rxConfig_t *rxConfig, rxRuntimeState_t *rxRuntimeState)
 {
     static uint16_t channelData[SRXL2_MAX_CHANNELS];
@@ -501,29 +621,13 @@ bool srxl2RxInit(const rxConfig_t *rxConfig, rxRuntimeState_t *rxRuntimeState)
     rxRuntimeState->rcFrameTimeUsFn = rxFrameTimeUs;
     rxRuntimeState->rcProcessFrameFn = srxl2ProcessFrame;
 
-    const serialPortConfig_t *portConfig = findSerialPortConfig(FUNCTION_RX_SERIAL);
-    if (!portConfig) {
-        return false;
+    // Serial port may have been initialized in srxl2InitSmartThrottle()
+    if (!serialPort) {
+        srxl2InitSerialPort(rxConfig);
     }
-
-    serialPort = openSerialPort(
-        portConfig->identifier,
-        FUNCTION_RX_SERIAL,
-        srxl2DataReceive,
-        NULL,
-        SRXL2_PORT_BAUDRATE_DEFAULT,
-        SRXL2_PORT_MODE,
-        SRXL2_PORT_OPTIONS |
-            (rxConfig->serialrx_inverted ? SERIAL_INVERTED : SERIAL_NOT_INVERTED) |
-            (rxConfig->halfDuplex ? SERIAL_BIDIR : SERIAL_UNIDIR) |
-            (rxConfig->pinSwap ? SERIAL_PINSWAP : SERIAL_NOSWAP)
-        );
-
     if (!serialPort) {
         return false;
     }
-
-    serialPort->idleCallback = srxl2Idle;
 
     state = ListenForActivity;
     timeoutTimestamp = micros() + SRXL2_LISTEN_FOR_ACTIVITY_TIMEOUT_US;

--- a/src/main/rx/srxl2.h
+++ b/src/main/rx/srxl2.h
@@ -16,4 +16,4 @@ bool srxl2TelemetryRequested(void);
 void srxl2InitializeFrame(struct sbuf_s *dst);
 void srxl2FinalizeFrame(struct sbuf_s *dst);
 void srxl2Bind(void);
-void srxl2InitSmartThrottle(const rxConfig_t *rxConfig);
+void srxl2RxEarlyInit(const rxConfig_t *rxConfig);

--- a/src/main/rx/srxl2.h
+++ b/src/main/rx/srxl2.h
@@ -16,3 +16,4 @@ bool srxl2TelemetryRequested(void);
 void srxl2InitializeFrame(struct sbuf_s *dst);
 void srxl2FinalizeFrame(struct sbuf_s *dst);
 void srxl2Bind(void);
+void srxl2InitSmartThrottle(const rxConfig_t *rxConfig);


### PR DESCRIPTION
Support Spektrum full size receivers by sending handshake packets at startup and when communications are lost.

It is necessary to set srxl2_unit_id = 0 to enable this.

A full size receiver may be connected to the FC via the "1" port to allow the receiver's SRXL2 port to be used for a remote receiver.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for SRXL2 Smart Throttle receivers.
  * Improved receiver startup with automatic device discovery and handshake communication.
  * Enhanced serial communication reliability through packet validation and response handling.

* **Bug Fixes**
  * Improved handling of baud-rate changes and receiver activity detection.
  * Prevented invalid packets from affecting receiver timing and processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->