### PR TITLE
Fixing Debug build for SRXL2 Code

### DIFF
--- a/src/main/drivers/srxl2_esc.c
+++ b/src/main/drivers/srxl2_esc.c
@@ -1165,14 +1165,17 @@ bool srxl2escCopyLatestTelemetry(srxl2escTelemetrySnapshot_t *out, uint32_t *out
 
     uint32_t seqStart;
     uint32_t seqEnd;
-    do {
+    for (;;) {
         seqStart = srxl2escLatestTelemetrySeq;
         if (seqStart & 1U) {
             continue;
         }
         *out = srxl2escLatestTelemetrySnapshot;
         seqEnd = srxl2escLatestTelemetrySeq;
-    } while (seqStart != seqEnd);
+        if (seqStart == seqEnd) {
+            break;
+        }
+    }
 
     if (outSeq) {
         *outSeq = seqEnd;


### PR DESCRIPTION
The seqlock read loop in srxl2escCopyLatestTelemetry() had a code path (continue on an odd/in-progress sequence number) that could reach the loop's exit check without seqEnd ever being assigned. A possible read of an uninitialized stack variable.

It only surfaced as a build failure in the DEBUG=GDB configuration because that target builds at -Og. GCC's -Wmaybe-uninitialized depends on the SSA-based dataflow analysis the optimizer performs, and -Og is the lowest optimization level.

The release build's -O2 -flto -ffast-math pipeline restructures the same loop aggressively enough (jump threading, PHI coalescing, cross-module propagation) that the analysis loses track of the pattern and stays silent, even though the compiled code still contains the identical uninitialized read.

The fix restructures the loop so the exit check is only ever reached after seqEnd has been assigned, eliminating the undefined path entirely.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved telemetry snapshot consistency by preventing incomplete or changing data from being read.
  * Telemetry retrieval now retries until a stable snapshot is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->