### PR TITLE
Saving Flash: Disable CMS

### DIFF
--- a/src/main/target/common_post.h
+++ b/src/main/target/common_post.h
@@ -24,6 +24,14 @@
 
 #include "build/version.h"
 
+// Disable the on-screen Configuration Menu System to free up flash.
+// USE_CRSF_CMS_TELEMETRY, USE_SPEKTRUM_CMS_TELEMETRY and USE_CMS_FAILSAFE_MENU
+// are undefined by the dependency handling further down; the two below are not
+// derived from USE_CMS anywhere, so they have to be undefined here.
+#undef USE_CMS
+#undef USE_EXTENDED_CMS_MENUS
+#undef USE_HOTT_TEXTMODE
+
 #if defined(USE_VTX_RTC6705_SOFTSPI)
 #define USE_VTX_RTC6705
 #endif


### PR DESCRIPTION
USE_CRSF_CMS_TELEMETRY, USE_SPEKTRUM_CMS_TELEMETRY and USE_CMS_FAILSAFE_MENU are already derived from USE_CMS by the existing dependency handling in common_post.h. USE_EXTENDED_CMS_MENUS and USE_HOTT_TEXTMODE are not, so they are undefined explicitly.

STM32F7X2:
flash −21,708 B (−4.70%, 94.01% → 89.59%)
RAM −3,700 B (−2.79%).

This shows what could be saved. Decision pending.
Configurator nees to reflect this change too ...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Disabled the on-screen Configuration Menu System and related text-mode menus in the build configuration.
  * Reduced firmware size by removing unused menu features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->