### PR TITLE
Saving Flash: Disable DShot Beacon

### DIFF
--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -3835,7 +3835,7 @@ static void processBeeperCommand(const char *cmdName, char *cmdline, uint32_t *o
     }
 }
 
-#if defined(USE_DSHOT)
+#if defined(USE_DSHOT_BEACON)
 static void cliBeacon(const char *cmdName, char *cmdline)
 {
     processBeeperCommand(cmdName, cmdline, &(beeperConfigMutable()->dshotBeaconOffFlags), DSHOT_BEACON_ALLOWED_MODES);
@@ -6536,7 +6536,7 @@ static void printConfig(const char *cmdName, char *cmdline, bool doDiff)
 #if defined(USE_BEEPER)
             printBeeper(dumpMask, beeperConfig_Copy.beeper_off_flags, beeperConfig()->beeper_off_flags, "beeper", BEEPER_ALLOWED_MODES, "beeper");
 
-#if defined(USE_DSHOT)
+#if defined(USE_DSHOT_BEACON)
             printBeeper(dumpMask, beeperConfig_Copy.dshotBeaconOffFlags, beeperConfig()->dshotBeaconOffFlags, "beacon", DSHOT_BEACON_ALLOWED_MODES, "beacon");
 #endif
 #endif // USE_BEEPER
@@ -6750,7 +6750,7 @@ const clicmd_t cmdTable[] = {
     CLI_COMMAND_DEF("batch", "start or end a batch of commands", "start | end", cliBatch),
 #endif
 #if defined(USE_BEEPER)
-#if defined(USE_DSHOT)
+#if defined(USE_DSHOT_BEACON)
     CLI_COMMAND_DEF("beacon", "enable/disable Dshot beacon for a condition", "list\r\n"
         "\t<->[name]", cliBeacon),
 #endif

--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -935,7 +935,7 @@ const clivalue_t valueTable[] = {
     { "beeper_frequency",           VAR_INT16  | HARDWARE_VALUE, .config.minmax = { 0, 16000 }, PG_BEEPER_DEV_CONFIG, offsetof(beeperDevConfig_t, frequency) },
 
 // PG_BEEPER_CONFIG
-#ifdef USE_DSHOT
+#ifdef USE_DSHOT_BEACON
     { "beeper_dshot_beacon_tone",   VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = {1, DSHOT_CMD_BEACON5 }, PG_BEEPER_CONFIG, offsetof(beeperConfig_t, dshotBeaconTone) },
 #endif
 #endif // USE_BEEPER

--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -482,7 +482,7 @@ static void validateAndFixConfig(void)
         beeperConfigMutable()->beeper_off_flags = 0;
     }
 
-#ifdef USE_DSHOT
+#ifdef USE_DSHOT_BEACON
     if (beeperConfig()->dshotBeaconOffFlags & ~DSHOT_BEACON_ALLOWED_MODES) {
         beeperConfigMutable()->dshotBeaconOffFlags = 0;
     }

--- a/src/main/fc/core.c
+++ b/src/main/fc/core.c
@@ -496,7 +496,7 @@ void tryArm(void)
 
         const timeUs_t currentTimeUs = micros();
 
-#ifdef USE_DSHOT
+#ifdef USE_DSHOT_BEACON
         if (currentTimeUs - getLastDshotBeaconCommandTimeUs() < DSHOT_BEACON_GUARD_DELAY_US) {
             armingDelayed = ARMING_DELAYED;
             return;

--- a/src/main/io/beeper.c
+++ b/src/main/io/beeper.c
@@ -82,7 +82,7 @@
 #define BEEPER_COMMAND_REPEAT 0xFE
 #define BEEPER_COMMAND_STOP   0xFF
 
-#ifdef USE_DSHOT
+#ifdef USE_DSHOT_BEACON
 static timeUs_t lastDshotBeaconCommandTimeUs;
 #endif
 
@@ -394,7 +394,7 @@ void beeperUpdate(timeUs_t currentTimeUs)
     }
 
     if (!beeperIsOn) {
-#ifdef USE_DSHOT
+#ifdef USE_DSHOT_BEACON
         if (!areMotorsRunning()
             && ((currentBeeperEntry->mode == BEEPER_RX_SET && !(beeperConfig()->dshotBeaconOffFlags & BEEPER_GET_FLAG(BEEPER_RX_SET)))
             || (currentBeeperEntry->mode == BEEPER_RX_LOST && !(beeperConfig()->dshotBeaconOffFlags & BEEPER_GET_FLAG(BEEPER_RX_LOST))))) {
@@ -530,7 +530,7 @@ bool isBeeperOn(void) {return false;}
 
 #endif
 
-#ifdef USE_DSHOT
+#ifdef USE_DSHOT_BEACON
 timeUs_t getLastDshotBeaconCommandTimeUs(void)
 {
     return lastDshotBeaconCommandTimeUs;

--- a/src/main/osd/osd_warnings.c
+++ b/src/main/osd/osd_warnings.c
@@ -109,7 +109,7 @@ void renderOsdWarning(char *warningText, bool *blinking, uint8_t *displayAttr)
         }
     }
 
-#ifdef USE_DSHOT
+#ifdef USE_DSHOT_BEACON
     if (isTryingToArm() && !ARMING_FLAG(ARMED)) {
         int armingDelayTime = (getLastDshotBeaconCommandTimeUs() + DSHOT_BEACON_GUARD_DELAY_US - currentTimeUs) / 1e5;
         if (armingDelayTime < 0) {
@@ -123,7 +123,7 @@ void renderOsdWarning(char *warningText, bool *blinking, uint8_t *displayAttr)
         *displayAttr = DISPLAYPORT_ATTR_INFO;
         return;
     }
-#endif // USE_DSHOT
+#endif // USE_DSHOT_BEACON
     if (osdWarnGetState(OSD_WARNING_FAIL_SAFE) && failsafeIsActive()) {
         tfp_sprintf(warningText, "FAIL SAFE");
         *displayAttr = DISPLAYPORT_ATTR_CRITICAL;

--- a/src/main/target/common_post.h
+++ b/src/main/target/common_post.h
@@ -24,6 +24,9 @@
 
 #include "build/version.h"
 
+// Disable the DShot beacon (motor locator tone) to free up flash.
+#undef USE_DSHOT_BEACON
+
 #if defined(USE_VTX_RTC6705_SOFTSPI)
 #define USE_VTX_RTC6705
 #endif
@@ -325,6 +328,7 @@
 #ifndef USE_DSHOT
 #undef USE_DSHOT_TELEMETRY
 #undef USE_DSHOT_BITBANG
+#undef USE_DSHOT_BEACON
 #endif
 
 #ifndef USE_DSHOT_TELEMETRY

--- a/src/main/target/common_pre.h
+++ b/src/main/target/common_pre.h
@@ -431,3 +431,9 @@ extern uint8_t _dmaram_end__;
 #endif
 
 #define MIN_PID_PROCESS_SPEED       800
+
+// The DShot beacon (motor locator tone) is available wherever DShot is.
+// Kept as its own switch so it can be compiled out independently of DShot.
+#ifdef USE_DSHOT
+#define USE_DSHOT_BEACON
+#endif


### PR DESCRIPTION
Introfucing define switch and then undefining it in common_post.h to free flash. Regular DShot motor output and the piezo beeper are unaffected.

STM32F7X2: 
flash −420 B (−0.09%), 
RAM −8 B.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added independent build-time control for the DShot beacon feature.
  * DShot beacon settings, commands, warnings, and arming safeguards are now available only when beacon support is enabled.

* **Bug Fixes**
  * Prevented DShot beacon functionality from being exposed or used on builds where it is disabled.
  * Disabled beacon support on configurations where it is not needed, reducing resource usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->