### PR TITLE
Saving Flash:  USB HID Joystick

### DIFF
--- a/src/main/target/common_post.h
+++ b/src/main/target/common_post.h
@@ -24,6 +24,11 @@
 
 #include "build/version.h"
 
+// Disable the USB HID joystick (composite CDC+HID device) to free up flash.
+// Undefined here, ahead of the USB dependency handling further down, so that
+// USE_USB_ADVANCED_PROFILES is still derived from USE_USB_MSC alone.
+#undef USE_USB_CDC_HID
+
 #if defined(USE_VTX_RTC6705_SOFTSPI)
 #define USE_VTX_RTC6705
 #endif


### PR DESCRIPTION
Compiles out the composite CDC+HID USB device (used to expose the FC as a joystick to RC simulators) freeing flash on all targets. 
The undef is placed ahead of the USB dependency handling in common_post.h so that USE_USB_ADVANCED_PROFILES is still derived from USE_USB_MSC alone. USB CDC (MSP/CLI) and USB MSC are unaffected.

STM32F7X2: 
flash −1,612 B (−0.35%), 
RAM −376 B (−0.28%).